### PR TITLE
Prevent pdf generation before graphs are rendered

### DIFF
--- a/src/api/utils/reports.py
+++ b/src/api/utils/reports.py
@@ -38,6 +38,11 @@ async def _download_pdf(report_type, uuid, cycle, auth_header=None):
         url, waitUntil="networkidle2",
     )
     await page.emulateMedia("screen")
+    if report_type == "yearly":
+        await page.waitForSelector('.last-yearly-graph')
+    elif report_type == "cycle":
+        await page.waitForSelector('.last-cycle-graph')
+    
     pdf_content = await page.pdf({"format": "Letter", "printBackground": True})
     await browser.close()
     return pdf_content


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Prevent pdf report from being generated before graphs are rendered. Added wait condition to pyppeteer to wait untill divs have been loaded to page from the last graph component on the report.

REQUIRES: CPA-513 pull request on web to be present to work correctly

## 💭 Motivation and Context

pdf's are being created prior to the ngx charts being populated (data is present on page but the graphs are not rendering)

<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
