### PR TITLE
get latest cycle for cycle report

### DIFF
--- a/src/api/serializers/subscriptions_serializers.py
+++ b/src/api/serializers/subscriptions_serializers.py
@@ -38,7 +38,7 @@ class SubscriptionTasksSerializer(serializers.Serializer):
     task_uuid = serializers.CharField()
     message_type = serializers.CharField()
     scheduled_date = serializers.DateTimeField()
-    queued = serializers.BooleanField(default=False)
+    queued = serializers.BooleanField(default=False, allow_null=True)
     executed = serializers.BooleanField(default=False)
     executed_date = serializers.DateTimeField(required=False, allow_null=True)
     error = serializers.CharField(required=False, allow_null=True, allow_blank=True)

--- a/src/api/utils/subscription/cycles.py
+++ b/src/api/utils/subscription/cycles.py
@@ -2,6 +2,7 @@
 # Third-Party Libraries
 from api.utils.generic import format_ztime
 from api.services import CampaignService
+from datetime import datetime
 
 campaign_service = CampaignService()
 
@@ -186,3 +187,13 @@ def get_cycle(subscription, cycle_data_override):
     for cycle in subscription["cycles"]:
         if cycle["cycle_uuid"] == cycle_data_override["cycle_uuid"]:
             return cycle
+
+
+def get_last_run_cycle(cycles):
+    now = datetime.now()
+    return min(
+        cycles,
+        key=lambda x: abs(
+            x["end_date"].replace(tzinfo=None) - now.replace(tzinfo=None)
+        ),
+    )

--- a/src/lambda_functions/tasks/process_tasks.py
+++ b/src/lambda_functions/tasks/process_tasks.py
@@ -4,6 +4,7 @@ import dateutil.parser
 
 from api.utils.subscription.static import YEARLY_MINUTES, MONTHLY_MINUTES, CYCLE_MINUTES
 from api.utils.subscription.subscriptions import send_start_notification
+from api.utils.subscription.cycles import get_last_run_cycle
 from api.utils.subscription import actions
 from api.services import SubscriptionService, CampaignService
 
@@ -138,7 +139,11 @@ def email_subscription_cycle(subscription):
     schedule the next subscription cycle report email
     """
     # Send email
-    sender = EmailSender(subscription, "cycle_report", datetime.now().isoformat())
+    selected_cycle = get_last_run_cycle(subscription["cycles"][-2:])
+
+    sender = EmailSender(
+        subscription, "cycle_report", selected_cycle["start_date"].isoformat()
+    )
     sender.send()
 
     context = {

--- a/src/lambda_functions/tasks/process_tasks.py
+++ b/src/lambda_functions/tasks/process_tasks.py
@@ -76,6 +76,7 @@ def add_new_task(subscription_uuid, scheduled_date, message_type):
             "message_type": message_type,
             "scheduled_date": new_date,
             "executed": False,
+            "queued": False,
         }
 
         logger.info(f"Adding new task {task}")

--- a/src/lambda_functions/tasks/queue_tasks.py
+++ b/src/lambda_functions/tasks/queue_tasks.py
@@ -42,7 +42,6 @@ def get_tasks_to_queue():
                 tasks_to_queue.append(
                     {"subscription_uuid": s["subscription_uuid"], "task": task}
                 )
-                task["queued"] = True
     return tasks_to_queue
 
 
@@ -51,6 +50,7 @@ def queue_tasks(tasks):
 
     for task in tasks:
         logger.info(f"Queueing task {task}")
+        task["queued"] = True
         sqs.send_message(
             QueueUrl=os.environ["TASKS_QUEUE_URL"],
             MessageBody=json.dumps(task, default=format_json),

--- a/tests/api/utils/susbscription/test_cycles.py
+++ b/tests/api/utils/susbscription/test_cycles.py
@@ -149,3 +149,27 @@ def test_get_cycle():
     cycle_data_override = {"cycle_uuid": "2"}
     result = cycles.get_cycle(subscription, cycle_data_override)
     assert result == {"cycle_uuid": "2"}
+
+
+def test_get_last_run_cycle():
+    data = [
+        {"end_date": datetime.now() - timedelta(minutes=5)},
+        {"end_date": datetime.now() + timedelta(days=3)},
+    ]
+    result = cycles.get_last_run_cycle(data)
+    assert result == data[0]
+
+    data = [
+        {"end_date": datetime.now() + timedelta(days=3)},
+    ]
+    result = cycles.get_last_run_cycle(data)
+    assert result == data[0]
+
+    data = [
+        {"end_date": datetime.now() - timedelta(minutes=5)},
+        {"end_date": datetime.now() - timedelta(minutes=3)},
+        {"end_date": datetime.now() - timedelta(minutes=1)},
+        {"end_date": datetime.now() + timedelta(days=3)},
+    ]
+    result = cycles.get_last_run_cycle(data)
+    assert result == data[2]


### PR DESCRIPTION
# <!--- Provide JIRA issue and general summary in title above. -->

## 💭 Description

<!--- Describe changes in detail -->

When the cycle report was being sent, a new cycle had been created and it sent the wrong cycle report at the end. This change makes it so that the latest, most complete cycle is selected for the cycle report.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [x] My code follows the code style of this project.
- [x] My changes have been adequetly tested locally.
- [x] All automated tests are passing.
- [x] I have updated/added required automated tests.
- [x] Precommit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->

Nothing else here.
