### PR TITLE
PCA-824 Yearly Report Targets

### DIFF
--- a/src/reports/utils.py
+++ b/src/reports/utils.py
@@ -508,22 +508,12 @@ def get_subscription_stats_for_yearly(subscription, start_date=None, end_date=No
             lambda x: x["campaign_id"] in campaigns_in_year, subscription["campaigns"]
         )
     )
-    all_targets_dirty = []
+    target_count = 0
     for campaign in subscription["campaigns"]:
         for cycle in cycles_in_year:
             if campaign["campaign_id"] in cycle["campaigns"]:
                 cycle["campaign_list"].append(campaign)
-                all_targets_dirty.extend(campaign["target_email_list"])
-
-    # remove dups in list of targets
-    all_targets_clean = []
-    [
-        all_targets_clean.append(x)
-        for x in all_targets_dirty
-        if x not in all_targets_clean
-    ]
-
-    total_unique_targets_in_year = len(all_targets_clean)
+                target_count += len(campaign["target_email_list"])
 
     # Loop through all campaigns in cycle. Check for unique moments, and appending to campaign_timeline_summary
 
@@ -540,7 +530,7 @@ def get_subscription_stats_for_yearly(subscription, start_date=None, end_date=No
             campaign_results, reported_override_val_total
         ),
         cycles_in_year,
-        total_unique_targets_in_year,
+        target_count,
     )
 
 

--- a/tests/api/utils/susbscription/test_cycles.py
+++ b/tests/api/utils/susbscription/test_cycles.py
@@ -133,10 +133,12 @@ def test_update_reported_emails(mock_update):
     assert mock_update.called
 
 
-def test_override_total_reported():
+@mock.patch("api.services.SubscriptionService.update_nested")
+def test_override_total_reported(mock_update):
     """Override Total Reported Test."""
     subscription = {
-        "cycles": [{"cycle_uuid": "1"}, {"cycle_uuid": "2"}, {"cycle_uuid": "3"}]
+        "cycles": [{"cycle_uuid": "1"}, {"cycle_uuid": "2"}, {"cycle_uuid": "3"}],
+        "subscription_uuid": "123",
     }
     cycles.override_total_reported(subscription, {"cycle_uuid": "2"})
     assert len(subscription["cycles"][1].keys()) == 1
@@ -148,6 +150,7 @@ def test_override_total_reported():
         subscription, {"cycle_uuid": "2", "override_total_reported": 3}
     )
     assert subscription["cycles"][1]["override_total_reported"] == 3
+    assert mock_update.called
 
 
 def test_get_cycle():

--- a/tests/api/views/landing_page_views/test_landing_page_list_view.py
+++ b/tests/api/views/landing_page_views/test_landing_page_list_view.py
@@ -36,14 +36,16 @@ def test_landing_page_list_view_get(mock_get_list, client):
     return_value=get_landing_page_object(),
 )
 @mock.patch("api.services.LandingPageService.save", return_value=landing_page())
+@mock.patch("api.services.LandingPageService.clear_and_set_default")
 @pytest.mark.django_db
 def test_landing_page_list_view_post(
-    mock_exists, mock_create_landing_page, mock_landing_save, client
+    mock_exists, mock_create_landing_page, mock_landing_save, mock_default, client
 ):
     """Test LandingPage ListView Post."""
     response = client.post("/api/v1/landingpages/", landing_page())
     assert mock_exists.called
     assert mock_create_landing_page.called
     assert mock_landing_save.called
+    assert mock_default.called
 
     assert response.status_code == 201

--- a/tests/api/views/template_views/test_template_stop_view.py
+++ b/tests/api/views/template_views/test_template_stop_view.py
@@ -9,25 +9,20 @@ import pytest
 from samples import subscription, template
 
 
+@mock.patch("api.services.CampaignService.get_list", return_value=[])
+@mock.patch("api.services.TemplateService.get", return_value=template())
+@mock.patch("api.services.TemplateService.update", return_value=template())
+@mock.patch(
+    "api.utils.subscription.actions.stop_subscription", return_value=subscription()
+)
 @pytest.mark.django_db
-def test_templates_view_stop_get(client):
+def test_templates_view_stop_get(
+    mock_stop, mock_update, mock_get_template, mock_get_list, client
+):
     """Test Get."""
-    with mock.patch(
-        "api.services.SubscriptionService.get_list",
-        return_value=[],
-    ) as mock_get_sub_list, mock.patch(
-        "api.services.TemplateService.get",
-        return_value=template(),
-    ) as mock_get_template, mock.patch(
-        "api.services.TemplateService.update",
-        return_value=template(),
-    ) as mock_update_template, mock.patch(
-        "api.utils.subscription.actions.stop_subscription",
-        return_value=subscription(),
-    ):
-        result = client.get("/api/v1/template/stop/1234/")
-        assert mock_get_sub_list.called
-        assert mock_get_template.called
-        assert mock_update_template.called
+    result = client.get("/api/v1/template/stop/1234/")
+    assert mock_get_list.called
+    assert mock_get_template.called
+    assert mock_update.called
 
-        assert result.status_code == 202
+    assert result.status_code == 202


### PR DESCRIPTION
# <!--- Provide JIRA issue and general summary in title above. -->

## 💭 Description

<!--- Describe changes in detail -->
Don't dedupe yearly report targets by email across cycles and campaigns. They may have the same email but they're different targets. Messes up statistics if they're deduped.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [x] My code follows the code style of this project.
- [x] My changes have been adequetly tested locally.
- [x] All automated tests are passing.
- [x] I have updated/added required automated tests.
- [x] Precommit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
