### PR TITLE
Region stats fix

### DIFF
--- a/src/api/utils/stats.py
+++ b/src/api/utils/stats.py
@@ -48,7 +48,7 @@ def get_related_customer_stats(customer):
         if c["industry"] == customer["industry"]:
             industry_customer_uuids.append(c["customer_uuid"])
 
-    subscriptions = subscription_service.get_list(parameters={"active": True})
+    subscriptions = subscription_service.get_list()
     sector_subscriptions = list(
         filter(lambda x: x["customer_uuid"] in sector_customer_uuids, subscriptions)
     )
@@ -58,6 +58,7 @@ def get_related_customer_stats(customer):
     customer_subscriptions = list(
         filter(lambda x: x["customer_uuid"] == customer["customer_uuid"], subscriptions)
     )
+    
 
     return {
         "national": get_simple_stats_from_subscriptions(subscriptions),

--- a/src/api/utils/stats.py
+++ b/src/api/utils/stats.py
@@ -58,7 +58,6 @@ def get_related_customer_stats(customer):
     customer_subscriptions = list(
         filter(lambda x: x["customer_uuid"] == customer["customer_uuid"], subscriptions)
     )
-    
 
     return {
         "national": get_simple_stats_from_subscriptions(subscriptions),


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Fix a bug on the cycle report in the Industry, National, Customer section. Previously no subscriptions were being used in the statistics. Change allows for all active cycles to be used in the statistic generation.

## 💭 Motivation and context ##

Fix a bug on the cycle report. Task PCA-901

## 🧪 Testing ##

Tested locally against multiple subscriptions locally. Ensuring that a mix of subscriptions are applied to the customer, industry, sector, and national regions to test all values that are generated on the statistic report.

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
