### PR TITLE
CPD-48 remove stagger delivery

### DIFF
--- a/scripts/create_large_subscription.py
+++ b/scripts/create_large_subscription.py
@@ -82,7 +82,6 @@
 #     "manually_stopped": True,
 #     "cycles": [],
 #     "email_report_history": [],
-#     "stagger_emails": False,
 # }
 
 # subscription_uuid = str(subscription_service.save(subscription)["subscription_uuid"])

--- a/src/api/serializers/subscriptions_serializers.py
+++ b/src/api/serializers/subscriptions_serializers.py
@@ -94,7 +94,6 @@ class SubscriptionSerializer(serializers.Serializer):
     tasks = SubscriptionTasksSerializer(many=True, required=False)
     cycles = CycleSerializer(required=False, many=True, allow_null=True)
     email_report_history = SubscriptionEmailHistorySerializer(required=False, many=True)
-    stagger_emails = serializers.BooleanField(required=False)
     continuous_subscription = serializers.BooleanField(default=True)
     cycle_length_minutes = serializers.IntegerField(required=False)
     # db data tracking added below
@@ -122,7 +121,6 @@ class SubscriptionPostSerializer(serializers.Serializer):
     templates_selected = SubscriptionTemplatesSelectedSerializer(required=True)
     sending_profile_name = serializers.CharField()
     active = serializers.BooleanField()
-    stagger_emails = serializers.BooleanField(default=True)
     continuous_subscription = serializers.BooleanField(default=True)
     cycle_length_minutes = serializers.IntegerField(
         default=129600, max_value=518400, min_value=15
@@ -155,7 +153,6 @@ class SubscriptionPatchSerializer(serializers.Serializer):
     manually_stopped = serializers.BooleanField(required=False, default=False)
     cycles = CycleSerializer(required=False, many=True)
     email_report_history = SubscriptionEmailHistorySerializer(required=False, many=True)
-    stagger_emails = serializers.BooleanField(required=False)
     continuous_subscription = serializers.BooleanField(required=False)
     cycle_length_minutes = serializers.IntegerField(
         required=False, max_value=518400, min_value=15
@@ -184,4 +181,3 @@ class SubscriptionQuerySerializer(serializers.Serializer):
     active = serializers.BooleanField(required=False)
     archived = serializers.BooleanField(default=False, required=False)
     manually_stopped = serializers.BooleanField(required=False)
-    stagger_emails = serializers.BooleanField(required=False)

--- a/src/api/utils/subscription/actions.py
+++ b/src/api/utils/subscription/actions.py
@@ -1,7 +1,6 @@
 """Subscription Actions."""
 # Standard Python Libraries
 import logging
-import random
 import uuid
 
 # cisagov Libraries
@@ -17,7 +16,6 @@ from api.utils.subscription.campaigns import generate_campaigns, stop_campaigns
 from api.utils.subscription.subscriptions import (
     calculate_subscription_start_end_date,
     create_subscription_name,
-    get_staggered_dates_in_range,
     get_subscription_cycles,
     init_subscription_tasks,
     send_stop_notification,
@@ -95,17 +93,10 @@ def start_subscription(subscription_uuid, new_cycle=False):
     # Get details for the customer that is attached to the subscription
     customer = customer_service.get(subscription["customer_uuid"])
 
-    # Divide stagger each start date and randomize:
-    if subscription["stagger_emails"]:
-        date_list = get_staggered_dates_in_range(start_date, 3)
-        date_list = random.sample(date_list, len(date_list))
-    else:
-        date_list = [start_date, start_date, start_date]
-
     # Create the needed subscription levels to fill.
     sub_levels = {
         "high": {
-            "start_date": date_list[0],
+            "start_date": start_date,
             "end_date": end_date,
             "template_targets": {},
             "template_uuids": subscription["templates_selected"]["high"],
@@ -114,7 +105,7 @@ def start_subscription(subscription_uuid, new_cycle=False):
             "deception_level": deception_level["high"],
         },
         "moderate": {
-            "start_date": date_list[1],
+            "start_date": start_date,
             "end_date": end_date,
             "template_targets": {},
             "template_uuids": subscription["templates_selected"]["moderate"],
@@ -123,7 +114,7 @@ def start_subscription(subscription_uuid, new_cycle=False):
             "deception_level": deception_level["moderate"],
         },
         "low": {
-            "start_date": date_list[2],
+            "start_date": start_date,
             "end_date": end_date,
             "template_targets": {},
             "template_uuids": subscription["templates_selected"]["low"],

--- a/src/api/utils/subscription/campaigns.py
+++ b/src/api/utils/subscription/campaigns.py
@@ -12,10 +12,7 @@ from api.manager import CampaignManager
 from api.serializers import campaign_serializers
 from api.services import CampaignService, LandingPageService
 from api.utils.generic import format_ztime
-from api.utils.subscription.subscriptions import (
-    get_campaign_minutes,
-    get_staggered_dates_in_range,
-)
+from api.utils.subscription.subscriptions import get_campaign_minutes
 from api.utils.subscription.targets import assign_targets
 from config.settings import DEFAULT_X_GOPHISH_CONTACT, GP_LANDING_SUBDOMAIN
 
@@ -67,15 +64,6 @@ def create_campaigns_for_level(subscription, sub_level, landing_page, cycle_uuid
         list(dict): gophish_campaigns
     """
     gophish_campaigns = []
-    if subscription["stagger_emails"]:
-        date_list = get_staggered_dates_in_range(
-            sub_level["start_date"],
-            len(sub_level["template_targets"]),
-        )
-    else:
-        date_list = []
-        for _ in range(len(sub_level["template_targets"])):
-            date_list.append(sub_level["start_date"])
 
     for index, k in enumerate(sub_level["template_targets"].keys()):
         template = list(
@@ -96,7 +84,7 @@ def create_campaigns_for_level(subscription, sub_level, landing_page, cycle_uuid
                 landing_page=landing_page_name,
                 template=template,
                 targets=sub_level["template_targets"][k],
-                start_date=date_list[index],
+                start_date=sub_level["start_date"],
                 deception_level=sub_level["deception_level"],
                 index=index,
                 cycle_uuid=cycle_uuid,

--- a/src/api/utils/subscription/subscriptions.py
+++ b/src/api/utils/subscription/subscriptions.py
@@ -113,25 +113,6 @@ def init_subscription_tasks(start_date, continuous_subscription, cycle_length_mi
     return tasks
 
 
-def get_staggered_dates_in_range(start, intv):
-    """
-    Get Staggered Dates.
-
-    Takes range of dates and gets N dates within them, returns a list of dates.
-
-    Args:
-        start (datetime): starting date of subscription
-        intv (int): number of inteval dates
-
-    Returns:
-        list[datetime]: list of N dates where N=intv
-    """
-    date_list = []
-    for i in range(intv):
-        date_list.append(start + timedelta(hours=i))
-    return date_list
-
-
 def add_remove_continuous_subscription_task(
     subscription_uuid, tasks, continuous_subscription
 ):

--- a/tests/api/utils/susbscription/test_subscriptions.py
+++ b/tests/api/utils/susbscription/test_subscriptions.py
@@ -190,16 +190,6 @@ def test_init_subscription_tasks():
     assert result[-1]["message_type"] == "stop_subscription"
 
 
-def test_get_staggered_dates_in_range():
-    """Test Stagger Dates."""
-    start = datetime.now()
-    result = subscriptions.get_staggered_dates_in_range(start, 3)
-    assert len(result) == 3
-    assert result[0] == start
-    assert result[1] == start + timedelta(hours=1)
-    assert result[2] == start + timedelta(hours=2)
-
-
 @mock.patch("api.services.SubscriptionService.update_nested")
 def test_add_remove_continuous_subscription_task(mock_update):
     """Test continuous subscription tasks."""


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Removed stagger delivery from a subscription.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
The purpose of this was to stagger email delivery so emails sent are built up. However, since the changes made in this [PR](https://github.com/cisagov/con-pca-api/pull/228), this is no longer required as now subscription lengths and counts are validated.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
* Pytests.
* Made sure I can restart a current subscription.
* Made sure I can create a new subscription.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
