### PR TITLE
Cpd 130 - Refresh Token Bug Fix

### DIFF
--- a/src/api/utils/aws_utils.py
+++ b/src/api/utils/aws_utils.py
@@ -197,7 +197,7 @@ class Cognito(AWS):
         )
 
     def sign_up(self, username, password, email):
-        """Sign up user in domain manager."""
+        """Sign up user """
         return self.client.sign_up(
             ClientId=COGNITO_CLIENT_ID,
             Username=username,

--- a/src/auth/views.py
+++ b/src/auth/views.py
@@ -46,7 +46,7 @@ class LoginView(APIView):
             response = cognito.authenticate(data["username"], data["password"])
         except botocore.exceptions.ClientError as e:
             logging.exception(e)
-            return Response(e.response["Error"]["Message"], 400)
+            return Response(e.response["Error"], 400)
 
         expires = now + timedelta(seconds=response["AuthenticationResult"]["ExpiresIn"])
 
@@ -71,7 +71,7 @@ class RefreshTokenView(APIView):
         data = request.data.copy()
         now = datetime.utcnow()
         response = cognito.refresh(data["refreshToken"])
-        expires = now + timedelta(seconds=response["AuthenticationResult"])
+        expires = now + timedelta(seconds=response["AuthenticationResult"]["ExpiresIn"])
         return Response(
             {
                 "id_token": response["AuthenticationResult"]["IdToken"],


### PR DESCRIPTION
## 🗣 Description ##

Add functionality to aws cognito utilities . Fix bug with the refresh jwt token method, accessing the expire time rather than the object containing it.

## 💭 Motivation and context ##

The refresh token method was returning a 404 error because it was not setting the expire time correctly. Fixed this issue.

## 🧪 Testing ##

Tested locally with a refresh time of 5 seconds and 1 hour to ensure that the refresh method performs at accelerated rates as well as normal operating times.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
