### PR TITLE
Allow for Deletion of Templates

### DIFF
--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -70,6 +70,8 @@ class TemplatesListView(APIView):
         created_response = template_service.save(post_data)
         return Response(created_response, status=status.HTTP_201_CREATED)
 
+    
+
 
 class TemplateView(APIView):
     """TemplateView."""
@@ -95,6 +97,35 @@ class TemplateView(APIView):
 
     def delete(self, request, template_uuid):
         """Delete method."""
+
+        #Get template
+        template = template_service.get(template_uuid)
+
+        #Check if retired
+        if not template['retired']:
+            return Response({"error":"You must retire the template first"}, status=status.HTTP_400_BAD_REQUEST)
+
+        #Check if its used in any campaigns
+        campaigns = campaign_service.get_list(
+            parameters={"template_uuid": template_uuid},
+            fields=["subscription_uuid"],
+        )
+        if len(campaigns) > 0:
+            return Response({
+                "error":"This template can not be deleted, it is associated with campaigns",
+                "campaigns": campaigns,
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        #check if a subscription has this tmeplate in the list of selected templates
+        subscriptions = subscription_service.get_list(
+            parameters={"archived": False},
+            fields=["templates_selected"],
+        )
+        templates_in_use = []
+        for sub in subscriptions:
+            for key in sub:
+                templates_in_use.append(sub[key])        
+
         delete_response = template_service.delete(template_uuid)
         return Response(delete_response, status=status.HTTP_200_OK)
 

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -119,7 +119,7 @@ class TemplateView(APIView):
         for sub in subscriptions:
             templates_selected = []
             [templates_selected.extend(v) for v in sub["templates_selected"].values()]
-            if templates_selected:
+            if template_uuid in templates_selected:
                 return Response(
                     {
                         "error": "This template cannot be deleted, it is assocated with subscriptions."

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -70,8 +70,6 @@ class TemplatesListView(APIView):
         created_response = template_service.save(post_data)
         return Response(created_response, status=status.HTTP_201_CREATED)
 
-    
-
 
 class TemplateView(APIView):
     """TemplateView."""
@@ -97,26 +95,31 @@ class TemplateView(APIView):
 
     def delete(self, request, template_uuid):
         """Delete method."""
-
-        #Get template
+        # Get template
         template = template_service.get(template_uuid)
 
-        #Check if retired
-        if not template['retired']:
-            return Response({"error":"You must retire the template first"}, status=status.HTTP_400_BAD_REQUEST)
+        # Check if retired
+        if not template["retired"]:
+            return Response(
+                {"error": "You must retire the template first"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        #Check if its used in any campaigns
+        # Check if its used in any campaigns
         campaigns = campaign_service.get_list(
             parameters={"template_uuid": template_uuid},
             fields=["subscription_uuid"],
         )
         if len(campaigns) > 0:
-            return Response({
-                "error":"This template can not be deleted, it is associated with campaigns",
-                "campaigns": campaigns,
-                }, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {
+                    "error": "This template can not be deleted, it is associated with campaigns",
+                    "campaigns": campaigns,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        #check if a subscription has this tmeplate in the list of selected templates
+        # check if a subscription has this tmeplate in the list of selected templates
         subscriptions = subscription_service.get_list(
             parameters={"archived": False},
             fields=["templates_selected"],
@@ -124,7 +127,7 @@ class TemplateView(APIView):
         templates_in_use = []
         for sub in subscriptions:
             for key in sub:
-                templates_in_use.append(sub[key])        
+                templates_in_use.append(sub[key])
 
         delete_response = template_service.delete(template_uuid)
         return Response(delete_response, status=status.HTTP_200_OK)

--- a/tests/api/views/template_views/test_template_view.py
+++ b/tests/api/views/template_views/test_template_view.py
@@ -42,7 +42,15 @@ def test_templates_view_delete(client):
         "api.services.CampaignService.exists", return_value=False
     ), mock.patch(
         "api.services.SubscriptionService.get_list",
-        return_value=[],
+        return_value=[
+            {
+                "templates_selected": {
+                    "low": ["1", "2"],
+                    "moderate": ["3, 4"],
+                    "high": ["5", "6"],
+                }
+            }
+        ],
     ), mock.patch(
         "api.services.TemplateService.get", return_value={"retired": True}
     ):

--- a/tests/api/views/template_views/test_template_view.py
+++ b/tests/api/views/template_views/test_template_view.py
@@ -34,10 +34,70 @@ def test_templates_view_get(client):
 
 def test_templates_view_delete(client):
     """Test Delete."""
+    # Test successful delete
     with mock.patch(
         "api.services.TemplateService.delete",
         return_value=template(),
-    ) as mock_delete:
+    ) as mock_delete, mock.patch(
+        "api.services.CampaignService.exists", return_value=False
+    ), mock.patch(
+        "api.services.SubscriptionService.get_list",
+        return_value=[],
+    ), mock.patch(
+        "api.services.TemplateService.get", return_value={"retired": True}
+    ):
         result = client.delete("/api/v1/template/1234/")
-        assert mock_delete.called
+        mock_delete.assert_called
         assert result.status_code == 200
+
+    # Test unretired template
+    with mock.patch(
+        "api.services.TemplateService.get", return_value={"retired": False}
+    ):
+        result = client.delete("/api/v1/template/1234/")
+        assert result.data == {"error": "You must retire the template first"}
+        mock_delete.assert_not_called
+        assert result.status_code == 400
+
+    # Test template used in campaign
+    with mock.patch(
+        "api.services.TemplateService.delete",
+        return_value=template(),
+    ) as mock_delete, mock.patch(
+        "api.services.TemplateService.get", return_value={"retired": True}
+    ), mock.patch(
+        "api.services.CampaignService.exists", return_value=True
+    ):
+        result = client.delete("/api/v1/template/1234/")
+        assert result.data == {
+            "error": "This template can not be deleted, it is associated with subscriptions."
+        }
+        mock_delete.assert_not_called
+        assert result.status_code == 400
+
+    # Test template in subscription
+    with mock.patch(
+        "api.services.TemplateService.delete",
+        return_value=template(),
+    ) as mock_delete, mock.patch(
+        "api.services.CampaignService.exists", return_value=False
+    ), mock.patch(
+        "api.services.SubscriptionService.get_list",
+        return_value=[
+            {
+                "templates_selected": {
+                    "low": ["1", "2"],
+                    "moderate": ["3, 4"],
+                    "high": ["1234"],
+                }
+            }
+        ],
+    ), mock.patch(
+        "api.services.TemplateService.get", return_value={"retired": True}
+    ):
+        result = client.delete("/api/v1/template/1234/")
+        assert result.data == {
+            "error": "This template cannot be deleted, it is assocated with subscriptions."
+        }
+        mock_delete.assert_not_called
+        assert result.status_code == 400


### PR DESCRIPTION
## 🗣 Description ##

Rework existing delete template components and update for current state of the application. API point added to delete template. Checks in place to ensure that a template is not removed if it is in use actively or for record keeping purposes.

## 💭 Motivation and context ##

Allow for deletion of templates.

## 🧪 Testing ##

Tested locally against multiple templates. Templates in active use by a subscription, templates that are no longer in active use but are tied to the reporting/statistics of previous subscriptions, and templates that are not in use at all.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [xThese code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
