### PR TITLE
Fix bug when templates selected doesn't exist

### DIFF
--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -118,7 +118,10 @@ class TemplateView(APIView):
         subscriptions = subscription_service.get_list(fields=["templates_selected"])
         for sub in subscriptions:
             templates_selected = []
-            [templates_selected.extend(v) for v in sub["templates_selected"].values()]
+            [
+                templates_selected.extend(v)
+                for v in sub.get("templates_selected", {}).values()
+            ]
             if template_uuid in templates_selected:
                 return Response(
                     {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Fix a bug with some subscriptions not having a field for templates selected. Usually old subscriptions.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
So we can delete templates.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
