### PR TITLE
CPD-183  Allow selecting a sending profile for a template

### DIFF
--- a/src/api/serializers/template_serializers.py
+++ b/src/api/serializers/template_serializers.py
@@ -44,6 +44,7 @@ class TemplateSerializer(serializers.Serializer):
     template_uuid = serializers.UUIDField()
     name = serializers.CharField()
     landing_page_uuid = serializers.CharField(default=None, allow_null=True)
+    sending_profile_id = serializers.IntegerField(default=None, allow_null=True)
     deception_score = serializers.IntegerField()
     descriptive_words = serializers.CharField(required=False, allow_null=True)
     description = serializers.CharField(allow_null=True)
@@ -72,6 +73,7 @@ class TemplatePostSerializer(serializers.Serializer):
 
     name = serializers.CharField()
     landing_page_uuid = serializers.CharField(required=False, allow_null=True)
+    sending_profile_id = serializers.IntegerField(required=False, allow_null=True)
     deception_score = serializers.IntegerField()
     descriptive_words = serializers.CharField(
         required=False, allow_null=True, allow_blank=True
@@ -99,6 +101,7 @@ class TemplatePatchSerializer(serializers.Serializer):
 
     name = serializers.CharField(required=False)
     landing_page_uuid = serializers.CharField(required=False, allow_null=True)
+    sending_profile_id = serializers.IntegerField(required=False, allow_null=True)
     deception_score = serializers.IntegerField(required=False)
     descriptive_words = serializers.CharField(required=False, allow_null=True)
     description = serializers.CharField(required=False, allow_null=True)
@@ -144,6 +147,7 @@ class TemplateQuerySerializer(serializers.Serializer):
     text = serializers.CharField(required=False)
     html = serializers.CharField(required=False)
     landing_page_uuid = serializers.CharField(required=False)
+    sending_profile_id = serializers.IntegerField(required=False)
     created_by = serializers.CharField(required=False)
     cb_timestamp = serializers.DateTimeField(required=False)
     last_updated_by = serializers.CharField(required=False)

--- a/src/api/utils/subscription/campaigns.py
+++ b/src/api/utils/subscription/campaigns.py
@@ -200,8 +200,6 @@ def create_campaign(
         campaign_name = f"{base_name}.{template['name']}.{campaign_start.strftime('%Y-%m-%d')}.{campaign_end.strftime('%Y-%m-%d')}"
 
         # Create Sending Profile
-        print("Template")
-        print(template)
         sending_profile = __create_campaign_smtp(
             campaign_name,
             template["from_address"],
@@ -276,9 +274,6 @@ def __create_campaign_smtp(
     sending_profile_name,
     template_sending_profile_id=None,
 ):
-    print("Creating SMTP")
-    print(template_sending_profile_id)
-    print(sending_profile_name)
     if template_sending_profile_id:
         sending_profile = campaign_manager.get_sending_profile(
             template_sending_profile_id

--- a/src/api/utils/subscription/campaigns.py
+++ b/src/api/utils/subscription/campaigns.py
@@ -200,11 +200,14 @@ def create_campaign(
         campaign_name = f"{base_name}.{template['name']}.{campaign_start.strftime('%Y-%m-%d')}.{campaign_end.strftime('%Y-%m-%d')}"
 
         # Create Sending Profile
+        print("Template")
+        print(template)
         sending_profile = __create_campaign_smtp(
             campaign_name,
             template["from_address"],
             subscription["subscription_uuid"],
             subscription["sending_profile_name"],
+            template.get("sending_profile_id"),
         )
         return_data.update(
             {"smtp": campaign_serializers.GoPhishSmtpSerializer(sending_profile).data}
@@ -270,15 +273,22 @@ def __create_campaign_smtp(
     campaign_name,
     template_from_address,
     subscription_uuid,
-    subscription_sending_profile_name,
+    sending_profile_name,
+    template_sending_profile_id=None,
 ):
-    sending_profiles = campaign_manager.get_sending_profile()
-    sending_profile = next(
-        iter(
-            [p for p in sending_profiles if p.name == subscription_sending_profile_name]
-        ),
-        None,
-    )
+    print("Creating SMTP")
+    print(template_sending_profile_id)
+    print(sending_profile_name)
+    if template_sending_profile_id:
+        sending_profile = campaign_manager.get_sending_profile(
+            template_sending_profile_id
+        )
+    else:
+        sending_profiles = campaign_manager.get_sending_profile()
+        sending_profile = next(
+            iter([p for p in sending_profiles if p.name == sending_profile_name]),
+            None,
+        )
     smtp = get_campaign_smtp(sending_profile, subscription_uuid, template_from_address)
 
     try:

--- a/src/api/utils/template/personalize.py
+++ b/src/api/utils/template/personalize.py
@@ -162,10 +162,6 @@ def personalize_template(customer_info, template_data, sub_data, tag_list):
         template_unique_name = "".join(template["name"].split(" "))
         cleantext += "\n {{.Tracker}} "
 
-        landing_page_uuid = ""
-        if "landing_page_uuid" in template:
-            landing_page_uuid = template["landing_page_uuid"]
-
         personalized_template_data.append(
             {
                 "template_uuid": template.get("template_uuid"),
@@ -173,7 +169,8 @@ def personalize_template(customer_info, template_data, sub_data, tag_list):
                 "name": template_unique_name,
                 "from_address": from_address,
                 "subject": subject,
-                "landing_page_uuid": landing_page_uuid,
+                "landing_page_uuid": template.get("landing_page_uuid", ""),
+                "sending_profile_id": template.get("sending_profile_id"),
             }
         )
 

--- a/src/api/views/sendingprofile_views.py
+++ b/src/api/views/sendingprofile_views.py
@@ -14,12 +14,13 @@ from api.serializers.sendingprofile_serializers import (
     SendingProfileDeleteResponseSerializer,
     SendingProfileSerializer,
 )
-from api.services import CampaignService
+from api.services import CampaignService, TemplateService
 from api.utils.subscription.campaigns import get_campaign_smtp
 
 # GoPhish API Manager
 campaign_manager = CampaignManager()
 campaign_service = CampaignService()
+template_service = TemplateService()
 
 
 class SendingProfilesListView(APIView):
@@ -100,6 +101,11 @@ class SendingProfileView(APIView):
 
     def delete(self, request, id):
         """Delete."""
+        if template_service.exists(parameters={"sending_profile_id": id}):
+            return Response(
+                {"error": "Templates are currently utilizing this sending profile."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         delete_response = campaign_manager.delete_sending_profile(smtp_id=id)
         serializer = SendingProfileDeleteResponseSerializer(delete_response)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/api/views/test_sending_profile_views.py
+++ b/tests/api/views/test_sending_profile_views.py
@@ -39,10 +39,20 @@ def test_sending_profile_delete(client):
     """Test Delete."""
     with mock.patch(
         "api.manager.CampaignManager.delete_sending_profile", return_value={"id": 1234}
-    ) as mock_delete_single:
+    ) as mock_delete_single, mock.patch(
+        "api.services.TemplateService.exists", return_value=False
+    ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         assert mock_delete_single.called
         assert result.status_code == 200
+    with mock.patch(
+        "api.manager.CampaignManager.delete_sending_profile", return_value={"id": 1234}
+    ) as mock_delete_single, mock.patch(
+        "api.services.TemplateService.exists", return_value=True
+    ):
+        result = client.delete("/api/v1/sendingprofile/1234/")
+        mock_delete_single.assert_not_called
+        assert result.status_code == 400
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Allows a sending profile to be assigned to a template and uses the template sending profile if it exists when a subscription runs.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
So we can closely gear template content to a sending domain.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Ran and tested locally by starting a subscription.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
