### PR TITLE
Fix deleting in use sending profiles

### DIFF
--- a/src/api/views/sendingprofile_views.py
+++ b/src/api/views/sendingprofile_views.py
@@ -14,13 +14,14 @@ from api.serializers.sendingprofile_serializers import (
     SendingProfileDeleteResponseSerializer,
     SendingProfileSerializer,
 )
-from api.services import CampaignService, TemplateService
+from api.services import CampaignService, SubscriptionService, TemplateService
 from api.utils.subscription.campaigns import get_campaign_smtp
 
 # GoPhish API Manager
 campaign_manager = CampaignManager()
 campaign_service = CampaignService()
 template_service = TemplateService()
+subscription_service = SubscriptionService()
 
 
 class SendingProfilesListView(APIView):
@@ -101,11 +102,24 @@ class SendingProfileView(APIView):
 
     def delete(self, request, id):
         """Delete."""
-        if template_service.exists(parameters={"sending_profile_id": id}):
+        sending_profile = campaign_manager.get_sending_profile(id)
+
+        if template_service.exists(parameters={"sending_profile_id": int(id)}):
             return Response(
                 {"error": "Templates are currently utilizing this sending profile."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        if subscription_service.exists(
+            parameters={"sending_profile_name": sending_profile.name}
+        ):
+            return Response(
+                {
+                    "error": "Subscriptions are currently utilizing this sending profile."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         delete_response = campaign_manager.delete_sending_profile(smtp_id=id)
         serializer = SendingProfileDeleteResponseSerializer(delete_response)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/api/views/test_sending_profile_views.py
+++ b/tests/api/views/test_sending_profile_views.py
@@ -37,18 +37,35 @@ def test_sending_profile_patch(client):
 @pytest.mark.django_db
 def test_sending_profile_delete(client):
     """Test Delete."""
+    # Test all good
     with mock.patch(
         "api.manager.CampaignManager.delete_sending_profile", return_value={"id": 1234}
     ) as mock_delete_single, mock.patch(
         "api.services.TemplateService.exists", return_value=False
+    ), mock.patch(
+        "api.services.SubscriptionService.exists", return_value=False
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         assert mock_delete_single.called
         assert result.status_code == 200
+    # Test template using sending profile
     with mock.patch(
         "api.manager.CampaignManager.delete_sending_profile", return_value={"id": 1234}
     ) as mock_delete_single, mock.patch(
         "api.services.TemplateService.exists", return_value=True
+    ), mock.patch(
+        "api.services.SubscriptionService.exists", return_value=False
+    ):
+        result = client.delete("/api/v1/sendingprofile/1234/")
+        mock_delete_single.assert_not_called
+        assert result.status_code == 400
+    # Test subscription using sending profile
+    with mock.patch(
+        "api.manager.CampaignManager.delete_sending_profile", return_value={"id": 1234}
+    ) as mock_delete_single, mock.patch(
+        "api.services.TemplateService.exists", return_value=False
+    ), mock.patch(
+        "api.services.SubscriptionService.exists", return_value=True
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         mock_delete_single.assert_not_called

--- a/tests/api/views/test_sending_profile_views.py
+++ b/tests/api/views/test_sending_profile_views.py
@@ -3,6 +3,7 @@
 from unittest import mock
 
 # Third-Party Libraries
+from gophish.models import SMTP
 import pytest
 
 # cisagov Libraries
@@ -44,6 +45,8 @@ def test_sending_profile_delete(client):
         "api.services.TemplateService.exists", return_value=False
     ), mock.patch(
         "api.services.SubscriptionService.exists", return_value=False
+    ), mock.patch(
+        "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         assert mock_delete_single.called
@@ -55,6 +58,8 @@ def test_sending_profile_delete(client):
         "api.services.TemplateService.exists", return_value=True
     ), mock.patch(
         "api.services.SubscriptionService.exists", return_value=False
+    ), mock.patch(
+        "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         mock_delete_single.assert_not_called
@@ -66,6 +71,8 @@ def test_sending_profile_delete(client):
         "api.services.TemplateService.exists", return_value=False
     ), mock.patch(
         "api.services.SubscriptionService.exists", return_value=True
+    ), mock.patch(
+        "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")
         mock_delete_single.assert_not_called


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Fixes deleting in-use sending profiles used by templates or subscriptions.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Will cause issues if you delete a sending profile that is currently in use.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
