### PR TITLE
add nonhuman indicator to org stats

### DIFF
--- a/src/api/utils/stats.py
+++ b/src/api/utils/stats.py
@@ -911,7 +911,14 @@ def get_asn_org_stats(timeline):
     sorted_timeline = sorted(timeline, key=lambda x: x.get("asn_org", "UNKNOWN"))
     response = []
     for org, events in groupby(sorted_timeline, lambda x: x.get("asn_org", "UNKNOWN")):
-        val = {"asn_org": org, "ips": set(), "cities": set(), "opens": 0, "clicks": 0}
+        val = {
+            "asn_org": org,
+            "is_non_human": is_nonhuman_event(org),
+            "ips": set(),
+            "cities": set(),
+            "opens": 0,
+            "clicks": 0,
+        }
         for event in events:
             if event.get("ip_address"):
                 val["ips"].add(event["ip_address"])


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Add nonhuman indicator to org stats.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
So we know whether asn org is flagged as a nonhuman.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
     to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
