### PR TITLE
CPD-239 Timezone Aware Datetimes

### DIFF
--- a/src/config/db.py
+++ b/src/config/db.py
@@ -23,5 +23,6 @@ def get_db():
         db_host=os.environ.get("DB_HOST"),
         db_port=os.environ.get("DB_PORT"),
     )
-    client = MongoClient(conn_str)
+    client = MongoClient(conn_str, tz_aware=True)
+
     return client.pca_data_dev


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Sets database to return datetimes as timezone aware.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
There are some issues with starting subscriptions at the correct time due to timezone info not being returned from the api.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Created a subscription and stopped/started multiple times to verify tasks were created at correct time.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
