### PR TITLE
CPD-255 allow for a user-defined cooldown period

### DIFF
--- a/src/api/serializers/subscriptions_serializers.py
+++ b/src/api/serializers/subscriptions_serializers.py
@@ -37,6 +37,7 @@ class CycleSerializer(serializers.Serializer):
     cycle_uuid = serializers.CharField()
     start_date = serializers.DateTimeField()
     end_date = serializers.DateTimeField()
+    send_by_date = serializers.DateTimeField(required=False)
     active = serializers.BooleanField()
     campaigns_in_cycle = serializers.ListField()
     phish_results = PhishingResultsSerializer()
@@ -96,6 +97,7 @@ class SubscriptionSerializer(serializers.Serializer):
     email_report_history = SubscriptionEmailHistorySerializer(required=False, many=True)
     continuous_subscription = serializers.BooleanField(default=True)
     cycle_length_minutes = serializers.IntegerField(required=False)
+    cooldown_minutes = serializers.IntegerField(required=False)
     report_frequency_minutes = serializers.IntegerField(required=False)
     # db data tracking added below
     created_by = serializers.CharField(required=False, max_length=100)
@@ -126,6 +128,9 @@ class SubscriptionPostSerializer(serializers.Serializer):
     cycle_length_minutes = serializers.IntegerField(
         default=129600, max_value=518400, min_value=15
     )  # max of 360 days, min of 15 minutes, default of 90 days
+    cooldown_minutes = serializers.IntegerField(
+        default=2880, max_value=518400, min_value=15
+    )  # max of 360 days, min of 15 minutes, default of 2 days
     report_frequency_minutes = serializers.IntegerField(
         default=43200, max_value=518400, min_value=15
     )  # max of 360 days, min of 15 minutes, default of 30 days
@@ -161,6 +166,9 @@ class SubscriptionPatchSerializer(serializers.Serializer):
     cycle_length_minutes = serializers.IntegerField(
         required=False, max_value=518400, min_value=15
     )  # max of 360 days, min of 15 minutes
+    cooldown_minutes = serializers.IntegerField(
+        required=False, max_value=518400, min_value=15
+    )  # max of 360 days, min of 15 minutes, default of 2 days
     report_frequency_minutes = serializers.IntegerField(
         required=False, max_value=518400, min_value=15
     )  # max of 360 days, min of 15 minutes

--- a/src/api/utils/subscription/campaigns.py
+++ b/src/api/utils/subscription/campaigns.py
@@ -12,7 +12,6 @@ from api.manager import CampaignManager
 from api.serializers import campaign_serializers
 from api.services import CampaignService, LandingPageService
 from api.utils.generic import format_ztime
-from api.utils.subscription.subscriptions import get_campaign_minutes
 from api.utils.subscription.targets import assign_targets
 from config.settings import DEFAULT_X_GOPHISH_CONTACT, GP_LANDING_SUBDOMAIN
 
@@ -202,9 +201,7 @@ def create_campaign(
         # Calculate Campaign Start and End Date
         campaign_start = start_date
         campaign_end = start_date + timedelta(
-            minutes=get_campaign_minutes(
-                subscription.get("cycle_length_minutes", 129600)
-            )
+            minutes=subscription.get("cycle_length_minutes", 129600)
         )
 
         # Generate Campaign Name

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -194,7 +194,8 @@ class SubscriptionValidView(APIView):
         """Post."""
         data = request.data.copy()
         is_valid, message = is_subscription_valid(
-            data["target_count"], data["cycle_minutes"]
+            data["target_count"],
+            data["cycle_minutes"],
         )
         if is_valid:
             return Response("Subscription is valid", status=status.HTTP_200_OK)

--- a/src/lambda_functions/tasks/process_tasks.py
+++ b/src/lambda_functions/tasks/process_tasks.py
@@ -49,6 +49,7 @@ def lambda_handler(event, context):
                     scheduled_date,
                     task["message_type"],
                     subscription.get("cycle_length_minutes", 129600),
+                    subscription.get("cooldown_minutes", 2880),
                     subscription.get("report_frequency_minutes", 43200),
                 )
             logger.info(f"Successfully executed task {task}")
@@ -75,6 +76,7 @@ def add_new_task(
     scheduled_date,
     message_type,
     cycle_length_minutes,
+    cooldown_minutes,
     report_frequency_minutes,
 ):
     """Add new task."""
@@ -82,9 +84,11 @@ def add_new_task(
 
     new_date = {
         "monthly_report": scheduled_date + timedelta(minutes=report_frequency_minutes),
-        "cycle_report": scheduled_date + timedelta(minutes=cycle_length_minutes),
+        "cycle_report": scheduled_date
+        + timedelta(minutes=(cycle_length_minutes + cooldown_minutes)),
         "yearly_report": scheduled_date + timedelta(minutes=get_yearly_minutes()),
-        "start_new_cycle": scheduled_date + timedelta(minutes=cycle_length_minutes),
+        "start_new_cycle": scheduled_date
+        + timedelta(minutes=(cycle_length_minutes + cooldown_minutes)),
     }.get(message_type)
 
     if new_date:

--- a/tests/lambda_functions/test_tasks.py
+++ b/tests/lambda_functions/test_tasks.py
@@ -24,10 +24,10 @@ def test_update_task(mock_update):
 def test_add_new_task(mock_push):
     """Test Add New Task."""
     now = datetime.now()
-    handler.add_new_task(fake.uuid4(), now, "monthly_report", 60, 15)
+    handler.add_new_task(fake.uuid4(), now, "monthly_report", 60, 15, 15)
     assert mock_push.call_count == 1
 
-    handler.add_new_task(fake.uuid4(), now, "nomessage", 60, 15)
+    handler.add_new_task(fake.uuid4(), now, "nomessage", 60, 15, 15)
     assert mock_push.call_count == 1
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Allows a user to define the cooldown period for a subscription.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Before, the cooldown period was calculated as a third of the subscription time. This met original requirements for most subscriptions running for 3 months with a 1 month period no emails would be sent. Now, these cooldown periods only need to be a couple days in some cases. This allows that cooldown period to be uniquely defined from subscription to subscription.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Ran a couple subscriptions locally and ran/modified pytests to make sure everything was working properly.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
