### PR TITLE
Return list of subscriptions using templates on delete

### DIFF
--- a/src/api/views/sendingprofile_views.py
+++ b/src/api/views/sendingprofile_views.py
@@ -110,13 +110,11 @@ class SendingProfileView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if subscription_service.exists(
-            parameters={"sending_profile_name": sending_profile.name}
-        ):
-            subs_using = subscription_service.get_list(
-                parameters={"sending_profile_name": sending_profile.name},
-                fields=["name"],
-            )
+        subs_using = subscription_service.get_list(
+            parameters={"sending_profile_name": sending_profile.name},
+            fields=["name"],
+        )
+        if subs_using:
             return Response(
                 {
                     "error": "Subscriptions are currently utilizing this sending profile.",

--- a/src/api/views/sendingprofile_views.py
+++ b/src/api/views/sendingprofile_views.py
@@ -113,9 +113,14 @@ class SendingProfileView(APIView):
         if subscription_service.exists(
             parameters={"sending_profile_name": sending_profile.name}
         ):
+            subs_using = subscription_service.get_list(
+                parameters={"sending_profile_name": sending_profile.name},
+                fields=["name"],
+            )
             return Response(
                 {
-                    "error": "Subscriptions are currently utilizing this sending profile."
+                    "error": "Subscriptions are currently utilizing this sending profile.",
+                    "fields": subs_using,
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/tests/api/views/test_sending_profile_views.py
+++ b/tests/api/views/test_sending_profile_views.py
@@ -72,6 +72,12 @@ def test_sending_profile_delete(client):
     ), mock.patch(
         "api.services.SubscriptionService.exists", return_value=True
     ), mock.patch(
+        "api.services.SubscriptionService.get_list",
+        return_value=[],
+    )as mock_get_list, mock.patch(
+        "api.services.CampaignService.get_list",
+        return_value=[],
+    ), mock.patch(
         "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
         result = client.delete("/api/v1/sendingprofile/1234/")

--- a/tests/api/views/test_sending_profile_views.py
+++ b/tests/api/views/test_sending_profile_views.py
@@ -44,7 +44,7 @@ def test_sending_profile_delete(client):
     ) as mock_delete_single, mock.patch(
         "api.services.TemplateService.exists", return_value=False
     ), mock.patch(
-        "api.services.SubscriptionService.exists", return_value=False
+        "api.services.SubscriptionService.get_list", return_value=[]
     ), mock.patch(
         "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
@@ -57,7 +57,7 @@ def test_sending_profile_delete(client):
     ) as mock_delete_single, mock.patch(
         "api.services.TemplateService.exists", return_value=True
     ), mock.patch(
-        "api.services.SubscriptionService.exists", return_value=False
+        "api.services.SubscriptionService.get_list", return_value=[]
     ), mock.patch(
         "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):
@@ -70,13 +70,7 @@ def test_sending_profile_delete(client):
     ) as mock_delete_single, mock.patch(
         "api.services.TemplateService.exists", return_value=False
     ), mock.patch(
-        "api.services.SubscriptionService.exists", return_value=True
-    ), mock.patch(
-        "api.services.SubscriptionService.get_list",
-        return_value=[],
-    )as mock_get_list, mock.patch(
-        "api.services.CampaignService.get_list",
-        return_value=[],
+        "api.services.SubscriptionService.get_list", return_value=["test"]
     ), mock.patch(
         "api.manager.CampaignManager.get_sending_profile", return_value=SMTP()
     ):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Return a list of subscriptions that are currently using a sending profile when attempting to delete the sending profile.

## 💭 Motivation and context ##

CPD-235 - Show error on deletion of a sending profile that is in use.

## 🧪 Testing ##

Tested locally to ensure an error occurs when attempting to delete. Returns a list of all subscriptions that are using when attempted.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
