### PR TITLE
cpd-81: remove S3 image upload url with base64

### DIFF
--- a/src/api/views/image_views.py
+++ b/src/api/views/image_views.py
@@ -1,29 +1,20 @@
 """Image Views."""
+# Standard Python Libraries
+import base64
+
 # Third-Party Libraries
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-# cisagov Libraries
-from api.utils.aws_utils import S3
 
 
 class ImageView(APIView):
     """ImageView."""
 
     def post(self, request, format=None):
-        """Post method."""
-        s3 = S3()
-        key, bucket, url = s3.upload_fileobj_image(
-            request.data["file"],
-        )
+        """Return base64 encode of an image file."""
+        base64_encode = base64.b64encode(request.data["file"].read())
 
-        result = {
-            "status": "true",
-            "bucket": bucket,
-            "key": key,
-            "msg": "Image Upload Successful",
-            "imageUrl": url,
-        }
+        result = {"imageUrl": f"data:image/jpeg;base64,{base64_encode.decode()}"}
 
         return Response(result, status=status.HTTP_201_CREATED)

--- a/tests/api/views/test_image_views.py
+++ b/tests/api/views/test_image_views.py
@@ -1,41 +1,35 @@
 """Image View Tests."""
 # Standard Python Libraries
+import base64
 from mimetypes import guess_type
-from unittest import mock
 
 # Third-Party Libraries
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from faker import Faker
 import pytest
-
-fake = Faker()
 
 
 @pytest.mark.django_db
 def test_image_view_post(client):
     """Test Image View Post."""
-    with mock.patch(
-        "api.utils.aws_utils.S3.upload_fileobj_image"
-    ) as mock_upload, mock.patch("boto3.client"):
-        uuid = fake.uuid4()
-        mock_upload.return_value = uuid, "testbucket", "testurl"
+    name = "src/static/img/cisa_logo.png"
+    with open(name, "rb") as f:
+        f.seek(0)
+        f.read()
+        size = f.tell()
+        f.seek(0)
+        content_type, charset = guess_type(name)
+        uf = InMemoryUploadedFile(
+            file=f,
+            name=name,
+            field_name=None,
+            content_type=content_type,
+            size=size,
+            charset=charset,
+        )
 
-        name = "src/static/img/cisa_logo.png"
-        with open(name, "rb") as f:
-            f.seek(0)
-            f.read()
-            size = f.tell()
-            f.seek(0)
-            content_type, charset = guess_type(name)
-            uf = InMemoryUploadedFile(
-                file=f,
-                name=name,
-                field_name=None,
-                content_type=content_type,
-                size=size,
-                charset=charset,
-            )
-
-            resp = client.post("/api/v1/imageupload/", data={"file": uf})
-        assert resp.status_code == 201
-        assert mock_upload.called
+        resp = client.post("/api/v1/imageupload/", data={"file": uf})
+    assert resp.status_code == 201
+    assert (
+        f"data:image/jpeg;base64,{base64.b64encode(base64.b64decode(uf))}"
+        == resp.json()["imageUrl"]
+    )

--- a/tests/api/views/test_image_views.py
+++ b/tests/api/views/test_image_views.py
@@ -1,6 +1,5 @@
 """Image View Tests."""
 # Standard Python Libraries
-import base64
 from mimetypes import guess_type
 
 # Third-Party Libraries
@@ -26,7 +25,6 @@ def test_image_view_post(client):
             size=size,
             charset=charset,
         )
-        b64uf = base64.b64encode(f.read())
         resp = client.post("/api/v1/imageupload/", data={"file": uf})
     assert resp.status_code == 201
-    assert f"data:image/jpeg;base64,{b64uf.decode()}" == resp.json()["imageUrl"]
+    assert resp.json()["imageUrl"].startswith("data:image/jpeg;base64")

--- a/tests/api/views/test_image_views.py
+++ b/tests/api/views/test_image_views.py
@@ -26,10 +26,7 @@ def test_image_view_post(client):
             size=size,
             charset=charset,
         )
-
+        b64uf = base64.b64encode(uf.read())
         resp = client.post("/api/v1/imageupload/", data={"file": uf})
     assert resp.status_code == 201
-    assert (
-        f"data:image/jpeg;base64,{base64.b64encode(base64.b64decode(uf))}"
-        == resp.json()["imageUrl"]
-    )
+    assert f"data:image/jpeg;base64,{b64uf.decode()}" == resp.json()["imageUrl"]

--- a/tests/api/views/test_image_views.py
+++ b/tests/api/views/test_image_views.py
@@ -26,7 +26,7 @@ def test_image_view_post(client):
             size=size,
             charset=charset,
         )
-        b64uf = base64.b64encode(uf.read())
+        b64uf = base64.b64encode(f.read())
         resp = client.post("/api/v1/imageupload/", data={"file": uf})
     assert resp.status_code == 201
     assert f"data:image/jpeg;base64,{b64uf.decode()}" == resp.json()["imageUrl"]


### PR DESCRIPTION
Add inline images in template and landing page editors using a base64 string.

## 🗣 Description ##
Initiate a post request with an image file and return a base64 string to render images directly in the html editor.

## 💭 Motivation and context ##
Remove S3 dependency and simplify backend workflow.

## 🧪 Testing ##
Tested locally using large images with success.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
