### PR TITLE
cpd-275: remove cisa logo from all emails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ redeploy: down build up
 shell:
 	docker exec -it pca-api python manage.py shell
 
-# target: build_emails: build mjml emails
+# target: build_emails: build mjml emails - requires: npm install -g mjml
 build_emails:
 	mjml src/templates/emails/mjml/* -o src/templates/emails/
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ redeploy: down build up
 shell:
 	docker exec -it pca-api python manage.py shell
 
+# target: build_emails: build mjml emails
+build_emails:
+	mjml src/templates/emails/mjml/* -o src/templates/emails/
+
 # target: dummy - initializes init_dummy_data for cpa
 dummy:
 	docker exec -it pca-api python scripts/create_dummy_data.py

--- a/src/api/notifications.py
+++ b/src/api/notifications.py
@@ -1,7 +1,6 @@
 """Notifications."""
 # Standard Python Libraries
 from datetime import datetime
-from email.mime.image import MIMEImage
 import logging
 import os
 
@@ -80,13 +79,13 @@ class EmailSender:
             bcc=self.bcc,
         )
 
-        image_files = ["cisa_logo.png"]
-        for image_file in image_files:
-            fp = open(os.path.abspath(f"{STATIC_DIR}/img/{image_file}"), "rb")
-            msgImage = MIMEImage(fp.read(), _subtype="png")
-            fp.close()
-            msgImage.add_header("Content-ID", f"<{image_file}>")
-            message.attach(msgImage)
+        # image_files = []
+        # for image_file in image_files:
+        #     fp = open(os.path.abspath(f"{STATIC_DIR}/img/{image_file}"), "rb")
+        #     msgImage = MIMEImage(fp.read(), _subtype="png")
+        #     fp.close()
+        #     msgImage.add_header("Content-ID", f"<{image_file}>")
+        #     message.attach(msgImage)
 
         message.attach_alternative(self.html_content, "text/html")
 
@@ -114,7 +113,6 @@ class EmailSender:
             bcc=self.bcc,
             text=self.text_content,
             html=self.html_content,
-            attachments=[os.path.abspath(f"{STATIC_DIR}/img/cisa_logo.png")],
             binary_attachments=binary_attachments,
         )
 

--- a/src/templates/emails/cycle_report.html
+++ b/src/templates/emails/cycle_report.html
@@ -6,25 +6,30 @@
 >
   <head>
     <title> </title>
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style type="text/css">
       #outlook a {
         padding: 0;
       }
+
       body {
         margin: 0;
         padding: 0;
         -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
       }
+
       table,
       td {
         border-collapse: collapse;
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
       }
+
       img {
         border: 0;
         height: auto;
@@ -33,11 +38,29 @@
         text-decoration: none;
         -ms-interpolation-mode: bicubic;
       }
+
       p {
         display: block;
         margin: 13px 0;
       }
     </style>
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG />
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+      <style type="text/css">
+        .mj-outlook-group-fix {
+          width: 100% !important;
+        }
+      </style>
+    <![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {
@@ -46,20 +69,18 @@
         }
       }
     </style>
-
-    <style type="text/css">
-      @media only screen and (max-width: 480px) {
-        table.mj-full-width-mobile {
-          width: 100% !important;
-        }
-        td.mj-full-width-mobile {
-          width: auto !important;
-        }
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
       }
     </style>
+    <style type="text/css"></style>
   </head>
-  <body>
+
+  <body style="word-spacing: normal">
     <div style="">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: 600px">
         <table
           align="center"
@@ -79,6 +100,7 @@
                   text-align: center;
                 "
               >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
                 <div
                   class="mj-column-per-100 mj-outlook-group-fix"
                   style="
@@ -98,190 +120,131 @@
                     style="vertical-align: top"
                     width="100%"
                   >
-                    <tr>
-                      <td
-                        align="center"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <table
-                          border="0"
-                          cellpadding="0"
-                          cellspacing="0"
-                          role="presentation"
-                          style="border-collapse: collapse; border-spacing: 0px"
-                        >
-                          <tbody>
-                            <tr>
-                              <td style="width: 100px">
-                                <img
-                                  height="auto"
-                                  src="cid:cisa_logo.png"
-                                  style="
-                                    border: 0;
-                                    display: block;
-                                    outline: none;
-                                    text-decoration: none;
-                                    height: auto;
-                                    width: 100%;
-                                    font-size: 13px;
-                                  "
-                                  width="100"
-                                />
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <p
+                    <tbody>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            border-top: solid 4px #1b2352;
-                            font-size: 1px;
-                            margin: 0px auto;
-                            width: 100%;
-                          "
-                        ></p>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Dear {{first_name}} {{last_name}},
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Dear {{ first_name }} {{ last_name }},
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Thank you for participating in the CISA Phishing
-                          Subscription Service Con-PCA. A new cycle is
-                          automatically started and has already begun.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Thank you for participating in the CISA Phishing
+                            Subscription Service Con-PCA. A new cycle is
+                            automatically started and has already begun.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          In the interests of security and efficiency, please
-                          respond to your DHS contact directly with any
-                          questions or concerns you may have
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            In the interests of security and efficiency, please
+                            respond to your DHS contact directly with any
+                            questions or concerns you may have
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Respectfully,
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Respectfully,
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          CISA Continuous Phishing Program Adminstrator
-                        </div>
-                      </td>
-                    </tr>
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            CISA Continuous Phishing Program Adminstrator
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
                   </table>
                 </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     </div>
   </body>
 </html>

--- a/src/templates/emails/mjml/cycle_report.mjml
+++ b/src/templates/emails/mjml/cycle_report.mjml
@@ -2,10 +2,6 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-image width="100px" src="cid:cisa_logo.png"></mj-image>
-
-        <mj-divider border-color="#1B2352"></mj-divider>
-
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Dear {{ first_name }} {{ last_name }},
         </mj-text>

--- a/src/templates/emails/mjml/monthly_report.mjml
+++ b/src/templates/emails/mjml/monthly_report.mjml
@@ -2,10 +2,6 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-image width="100px" src="cid:cisa_logo.png"></mj-image>
-
-        <mj-divider border-color="#1B2352"></mj-divider>
-
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Dear {{ first_name }} {{ last_name }},
         </mj-text>

--- a/src/templates/emails/mjml/subscription_started.mjml
+++ b/src/templates/emails/mjml/subscription_started.mjml
@@ -1,4 +1,4 @@
-{% load tz %}
+<mj-raw> {% load tz %} </mj-raw>
 <mjml>
   <mj-head>
     <mj-style> ul li { background: #cce5ff; margin: 10px; } </mj-style>

--- a/src/templates/emails/mjml/subscription_started.mjml
+++ b/src/templates/emails/mjml/subscription_started.mjml
@@ -11,8 +11,8 @@
         </mj-text>
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Thank you for participating in the CISA Phishing This email is to
-          inform you that your campaign has begun starting {% localtime on %}{{
-          start_date }}{% endlocaltime %} UTC and will run until {{ end_date }}
+          inform you that your campaign has begun starting
+          {{start_date|localtime}} UTC and will run until {{end_date|localtime}}
           UTC.
         </mj-text>
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">

--- a/src/templates/emails/mjml/subscription_started.mjml
+++ b/src/templates/emails/mjml/subscription_started.mjml
@@ -6,8 +6,6 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-image width="100px" src="cid:cisa_logo.png"></mj-image>
-        <mj-divider border-color="#1B2352"></mj-divider>
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Dear {{ first_name }} {{ last_name }},
         </mj-text>

--- a/src/templates/emails/mjml/subscription_stopped.mjml
+++ b/src/templates/emails/mjml/subscription_stopped.mjml
@@ -1,4 +1,4 @@
-{% load tz %}
+<mj-raw> {% load tz %} </mj-raw>
 <mjml>
   <mj-body>
     <mj-section>

--- a/src/templates/emails/mjml/subscription_stopped.mjml
+++ b/src/templates/emails/mjml/subscription_stopped.mjml
@@ -9,8 +9,8 @@
 
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Thank you for participating in the CISA Phishing. This email is to
-          inform you that your campaign has been stopped on {% localtime on %}{{
-          end_date }}{% endlocaltime %} UTC.
+          inform you that your campaign has been stopped on
+          {{end_date|localtime}} UTC.
         </mj-text>
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           In the interests of security and efficiency, please respond to your

--- a/src/templates/emails/mjml/subscription_stopped.mjml
+++ b/src/templates/emails/mjml/subscription_stopped.mjml
@@ -3,10 +3,6 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-image width="100px" src="cid:cisa_logo.png"></mj-image>
-
-        <mj-divider border-color="#1B2352"></mj-divider>
-
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Dear {{ first_name }} {{ last_name }},
         </mj-text>

--- a/src/templates/emails/mjml/yearly_report.mjml
+++ b/src/templates/emails/mjml/yearly_report.mjml
@@ -2,10 +2,6 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-image width="100px" src="cid:cisa_logo.png"></mj-image>
-
-        <mj-divider border-color="#1B2352"></mj-divider>
-
         <mj-text font-size="20px" color="#1B2352" font-family="helvetica">
           Dear {{ first_name }} {{ last_name }},
         </mj-text>

--- a/src/templates/emails/monthly_report.html
+++ b/src/templates/emails/monthly_report.html
@@ -6,7 +6,7 @@
 >
   <head>
     <title> </title>
-    <!--[if !mso]><!-- -->
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -15,18 +15,21 @@
       #outlook a {
         padding: 0;
       }
+
       body {
         margin: 0;
         padding: 0;
         -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
       }
+
       table,
       td {
         border-collapse: collapse;
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
       }
+
       img {
         border: 0;
         height: auto;
@@ -35,11 +38,29 @@
         text-decoration: none;
         -ms-interpolation-mode: bicubic;
       }
+
       p {
         display: block;
         margin: 13px 0;
       }
     </style>
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG />
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+      <style type="text/css">
+        .mj-outlook-group-fix {
+          width: 100% !important;
+        }
+      </style>
+    <![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {
@@ -48,20 +69,18 @@
         }
       }
     </style>
-
-    <style type="text/css">
-      @media only screen and (max-width: 480px) {
-        table.mj-full-width-mobile {
-          width: 100% !important;
-        }
-        td.mj-full-width-mobile {
-          width: auto !important;
-        }
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
       }
     </style>
+    <style type="text/css"></style>
   </head>
-  <body>
+
+  <body style="word-spacing: normal">
     <div style="">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: 600px">
         <table
           align="center"
@@ -81,6 +100,7 @@
                   text-align: center;
                 "
               >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
                 <div
                   class="mj-column-per-100 mj-outlook-group-fix"
                   style="
@@ -100,190 +120,131 @@
                     style="vertical-align: top"
                     width="100%"
                   >
-                    <tr>
-                      <td
-                        align="center"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <table
-                          border="0"
-                          cellpadding="0"
-                          cellspacing="0"
-                          role="presentation"
-                          style="border-collapse: collapse; border-spacing: 0px"
-                        >
-                          <tbody>
-                            <tr>
-                              <td style="width: 100px">
-                                <img
-                                  height="auto"
-                                  src="cid:cisa_logo.png"
-                                  style="
-                                    border: 0;
-                                    display: block;
-                                    outline: none;
-                                    text-decoration: none;
-                                    height: auto;
-                                    width: 100%;
-                                    font-size: 13px;
-                                  "
-                                  width="100"
-                                />
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <p
+                    <tbody>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            border-top: solid 4px #1b2352;
-                            font-size: 1px;
-                            margin: 0px auto;
-                            width: 100%;
-                          "
-                        ></p>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Dear {{first_name}} {{last_name}},
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Dear {{ first_name }} {{ last_name }},
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Thank you for participating in the CISA Phishing
-                          Subscription Service Con-PCA. Attached is your monthly
-                          phishing progress report for your review.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Thank you for participating in the CISA Phishing
+                            Subscription Service Con-PCA. Attached is your
+                            monthly phishing progress report for your review.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          In the interests of security and efficiency, please
-                          respond to your CISA contact directly with any
-                          questions or concerns you may have
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            In the interests of security and efficiency, please
+                            respond to your DHS contact directly with any
+                            questions or concerns you may have
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Respectfully,
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Respectfully,
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          CISA Continuous Phishing Program Adminstrator
-                        </div>
-                      </td>
-                    </tr>
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            CISA Continuous Phishing Program Adminstrator
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
                   </table>
                 </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     </div>
   </body>
 </html>

--- a/src/templates/emails/subscription_started.html
+++ b/src/templates/emails/subscription_started.html
@@ -1,3 +1,4 @@
+{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"

--- a/src/templates/emails/subscription_started.html
+++ b/src/templates/emails/subscription_started.html
@@ -1,4 +1,3 @@
-{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"
@@ -170,9 +169,8 @@
                           >
                             Thank you for participating in the CISA Phishing
                             This email is to inform you that your campaign has
-                            begun starting {% localtime on %}{{ start_date }}{%
-                            endlocaltime %} UTC and will run until {{ end_date
-                            }} UTC.
+                            begun starting {{start_date|localtime}} UTC and will
+                            run until {{end_date|localtime}} UTC.
                           </div>
                         </td>
                       </tr>

--- a/src/templates/emails/subscription_started.html
+++ b/src/templates/emails/subscription_started.html
@@ -1,4 +1,3 @@
-{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"
@@ -7,7 +6,9 @@
 >
   <head>
     <title> </title>
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style type="text/css">
@@ -43,6 +44,23 @@
         margin: 13px 0;
       }
     </style>
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG />
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+      <style type="text/css">
+        .mj-outlook-group-fix {
+          width: 100% !important;
+        }
+      </style>
+    <![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {
@@ -51,27 +69,24 @@
         }
       }
     </style>
-
-    <style type="text/css">
-      @media only screen and (max-width: 480px) {
-        table.mj-full-width-mobile {
-          width: 100% !important;
-        }
-
-        td.mj-full-width-mobile {
-          width: auto !important;
-        }
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
       }
     </style>
+    <style type="text/css"></style>
     <style type="text/css">
       ul li {
+        background: #cce5ff;
         margin: 10px;
       }
     </style>
   </head>
 
-  <body>
+  <body style="word-spacing: normal">
     <div style="">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: 600px">
         <table
           align="center"
@@ -91,6 +106,7 @@
                   text-align: center;
                 "
               >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
                 <div
                   class="mj-column-per-100 mj-outlook-group-fix"
                   style="
@@ -110,274 +126,171 @@
                     style="vertical-align: top"
                     width="100%"
                   >
-                    <tr>
-                      <td
-                        align="center"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <table
-                          border="0"
-                          cellpadding="0"
-                          cellspacing="0"
-                          role="presentation"
-                          style="border-collapse: collapse; border-spacing: 0px"
-                        >
-                          <tbody>
-                            <tr>
-                              <td style="width: 100px">
-                                <img
-                                  height="auto"
-                                  src="cid:cisa_logo.png"
-                                  style="
-                                    border: 0;
-                                    display: block;
-                                    outline: none;
-                                    text-decoration: none;
-                                    height: auto;
-                                    width: 100%;
-                                    font-size: 13px;
-                                  "
-                                  width="100"
-                                />
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <p
+                    <tbody>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            border-top: solid 4px #1b2352;
-                            font-size: 1px;
-                            margin: 0px auto;
-                            width: 100%;
-                          "
-                        ></p>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Dear {{first_name}} {{last_name}},
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Dear {{ first_name }} {{ last_name }},
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Thank you for participating in CISA Continuous
-                          Phishing (Con-PCA). This email is to inform you that
-                          your campaign has begun starting
-                          {{start_date|localtime}} UTC and will run until
-                          {{end_date|localtime}} UTC.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Thank you for participating in the CISA Phishing
+                            This email is to inform you that your campaign has
+                            begun starting {% localtime on %}{{ start_date }}{%
+                            endlocaltime %} UTC and will run until {{ end_date
+                            }} UTC.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          The following template subjects will be used over the
-                          duration of this cycle.
-                          <ul>
-                            {% for template in templates %}
-                            <li>{{template.subject}}</li>
-                            {% endfor %}
-                          </ul>
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            To assist you in differentianting between DHS
+                            Con-PCA phishing exercise emails and actual phishing
+                            attempts please use the following:
+                            <ul>
+                              <li>
+                                All emails coming from the Con-PCA program will
+                                have a custom header DHS-PHISH:{{cycle_uuid}}}.
+                                Please look for this header the value for this
+                                header is unique to your subscription and
+                                changes every 90 days or more frequently.
+                              </li>
+                              <li>
+                                The whois guard for all Con-PCA domains is
+                                turned off. Doing a whois lookup on the actual
+                                sender domain will show the domain owner as DHS.
+                              </li>
+                            </ul>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          To assist you in differentiating between CISA Con-PCA
-                          phishing exercise emails and actual phishing attempts
-                          please use the following:
-                          <ul>
-                            <li>
-                              All phishing emails from the Con-PCA program will
-                              come from the following domain:
-                              <br /><br />{{phishing_domain}}<br /><br />
-                              This will be the sending domain for the current
-                              cycle, but different display names will be used
-                              based upon the email template. This sending domain
-                              may change between cycles.
-                            </li>
-                            <li>
-                              All emails coming from the Con-PCA program will
-                              have a custom header:
-                              <br /><br />CISA-PHISH:{{subscription_uuid}}<br /><br />
-                              Please look for this header. The value for the
-                              header is unique to your subscription and changes
-                              each cycle.
-                            </li>
-                            <!-- <li>
-                              The whois guard for all Con-PCA domains is turned
-                              off. Doing a whois lookup on the actual sender
-                              domain will show the domain owner as DHS.
-                            </li> -->
-                            <li>
-                              You have enrolled {{email_count}} Emails in this
-                              campaign.
-                            </li>
-                          </ul>
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            In the interests of security and efficiency, please
+                            respond to your DHS contact directly with any
+                            questions or concerns you may have
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          In the interests of security and efficiency, please
-                          respond to {{x_gophish_contact}} directly with any
-                          questions or concerns you may have.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Respectfully,
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Respectfully,
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
-                          "
-                        >
-                          CISA Continuous Phishing Program Administrator
-                        </div>
-                      </td>
-                    </tr>
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            CISA Continuous Phishing Program Adminstrator
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
                   </table>
                 </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     </div>
   </body>
 </html>

--- a/src/templates/emails/subscription_stopped.html
+++ b/src/templates/emails/subscription_stopped.html
@@ -1,3 +1,4 @@
+{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"

--- a/src/templates/emails/subscription_stopped.html
+++ b/src/templates/emails/subscription_stopped.html
@@ -1,4 +1,3 @@
-{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"
@@ -164,8 +163,7 @@
                           >
                             Thank you for participating in the CISA Phishing.
                             This email is to inform you that your campaign has
-                            been stopped on {% localtime on %}{{ end_date }}{%
-                            endlocaltime %} UTC.
+                            been stopped on {{end_date|localtime}} UTC.
                           </div>
                         </td>
                       </tr>

--- a/src/templates/emails/subscription_stopped.html
+++ b/src/templates/emails/subscription_stopped.html
@@ -1,4 +1,3 @@
-{% load tz %}
 <!DOCTYPE html>
 <html
   xmlns="http://www.w3.org/1999/xhtml"
@@ -7,7 +6,9 @@
 >
   <head>
     <title> </title>
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style type="text/css">
@@ -43,6 +44,23 @@
         margin: 13px 0;
       }
     </style>
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG />
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+      <style type="text/css">
+        .mj-outlook-group-fix {
+          width: 100% !important;
+        }
+      </style>
+    <![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {
@@ -51,22 +69,18 @@
         }
       }
     </style>
-
-    <style type="text/css">
-      @media only screen and (max-width: 480px) {
-        table.mj-full-width-mobile {
-          width: 100% !important;
-        }
-
-        td.mj-full-width-mobile {
-          width: auto !important;
-        }
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
       }
     </style>
+    <style type="text/css"></style>
   </head>
 
-  <body>
+  <body style="word-spacing: normal">
     <div style="">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: 600px">
         <table
           align="center"
@@ -86,6 +100,7 @@
                   text-align: center;
                 "
               >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
                 <div
                   class="mj-column-per-100 mj-outlook-group-fix"
                   style="
@@ -105,212 +120,132 @@
                     style="vertical-align: top"
                     width="100%"
                   >
-                    <tr>
-                      <td
-                        align="center"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <table
-                          border="0"
-                          cellpadding="0"
-                          cellspacing="0"
-                          role="presentation"
-                          style="border-collapse: collapse; border-spacing: 0px"
-                        >
-                          <tbody>
-                            <tr>
-                              <td style="width: 100px">
-                                <img
-                                  height="auto"
-                                  src="cid:cisa_logo.png"
-                                  style="
-                                    border: 0;
-                                    display: block;
-                                    outline: none;
-                                    text-decoration: none;
-                                    height: auto;
-                                    width: 100%;
-                                    font-size: 13px;
-                                  "
-                                  width="100"
-                                />
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <p
+                    <tbody>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            border-top: solid 4px #1b2352;
-                            font-size: 1px;
-                            margin: 0px auto;
-                            width: 100%;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
-                        ></p>
-
-                        <!--[if mso | IE]>
-                          <table
-                            align="center"
-                            border="0"
-                            cellpadding="0"
-                            cellspacing="0"
+                        >
+                          <div
                             style="
-                              border-top: solid 4px #1b2352;
-                              font-size: 1px;
-                              margin: 0px auto;
-                              width: 550px;
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
                             "
-                            role="presentation"
-                            width="550px"
                           >
-                            <tr>
-                              <td style="height: 0; line-height: 0">&nbsp;</td>
-                            </tr>
-                          </table>
-                        <![endif]-->
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                            Dear {{ first_name }} {{ last_name }},
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Dear {{first_name}} {{last_name}},
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Thank you for participating in the CISA Phishing.
+                            This email is to inform you that your campaign has
+                            been stopped on {% localtime on %}{{ end_date }}{%
+                            endlocaltime %} UTC.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Thank you for participating in CISA Continuous
-                          Phishing (Con-PCA). This email is to inform you that
-                          your campaign has been stopped on
-                          {{end_date|localtime}} UTC.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            In the interests of security and efficiency, please
+                            respond to your DHS contact directly with any
+                            questions or concerns you may have
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          In the interests of security and efficiency, please
-                          respond to your CISA contact directly with any
-                          questions or concerns you may have.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Respectfully,
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Respectfully,
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
-                          "
-                        >
-                          CISA Continuous Phishing Program Adminstrator
-                        </div>
-                      </td>
-                    </tr>
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            CISA Continuous Phishing Program Adminstrator
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
                   </table>
                 </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     </div>
   </body>
 </html>

--- a/src/templates/emails/yearly_report.html
+++ b/src/templates/emails/yearly_report.html
@@ -6,25 +6,30 @@
 >
   <head>
     <title> </title>
+    <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style type="text/css">
       #outlook a {
         padding: 0;
       }
+
       body {
         margin: 0;
         padding: 0;
         -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
       }
+
       table,
       td {
         border-collapse: collapse;
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
       }
+
       img {
         border: 0;
         height: auto;
@@ -33,11 +38,29 @@
         text-decoration: none;
         -ms-interpolation-mode: bicubic;
       }
+
       p {
         display: block;
         margin: 13px 0;
       }
     </style>
+    <!--[if mso]>
+      <noscript>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG />
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+      <style type="text/css">
+        .mj-outlook-group-fix {
+          width: 100% !important;
+        }
+      </style>
+    <![endif]-->
     <style type="text/css">
       @media only screen and (min-width: 480px) {
         .mj-column-per-100 {
@@ -46,20 +69,18 @@
         }
       }
     </style>
-
-    <style type="text/css">
-      @media only screen and (max-width: 480px) {
-        table.mj-full-width-mobile {
-          width: 100% !important;
-        }
-        td.mj-full-width-mobile {
-          width: auto !important;
-        }
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
       }
     </style>
+    <style type="text/css"></style>
   </head>
-  <body>
+
+  <body style="word-spacing: normal">
     <div style="">
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin: 0px auto; max-width: 600px">
         <table
           align="center"
@@ -79,6 +100,7 @@
                   text-align: center;
                 "
               >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
                 <div
                   class="mj-column-per-100 mj-outlook-group-fix"
                   style="
@@ -98,190 +120,131 @@
                     style="vertical-align: top"
                     width="100%"
                   >
-                    <tr>
-                      <td
-                        align="center"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <table
-                          border="0"
-                          cellpadding="0"
-                          cellspacing="0"
-                          role="presentation"
-                          style="border-collapse: collapse; border-spacing: 0px"
-                        >
-                          <tbody>
-                            <tr>
-                              <td style="width: 100px">
-                                <img
-                                  height="auto"
-                                  src="cid:cisa_logo.png"
-                                  style="
-                                    border: 0;
-                                    display: block;
-                                    outline: none;
-                                    text-decoration: none;
-                                    height: auto;
-                                    width: 100%;
-                                    font-size: 13px;
-                                  "
-                                  width="100"
-                                />
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <p
+                    <tbody>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            border-top: solid 4px #1b2352;
-                            font-size: 1px;
-                            margin: 0px auto;
-                            width: 100%;
-                          "
-                        ></p>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
-                          style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Dear {{first_name}} {{last_name}},
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Dear {{ first_name }} {{ last_name }},
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Thank you for participating in the CISA Phishing
-                          Subscription Service Con-PCA. Attached is your yearly
-                          phishing report for your review.
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Thank you for participating in the CISA Phishing
+                            Subscription Service Con-PCA. Attached is your
+                            yearly phishing report for your review.
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          In the interests of security and efficiency, please
-                          respond to your DHS contact directly with any
-                          questions or concerns you may have
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            In the interests of security and efficiency, please
+                            respond to your DHS contact directly with any
+                            questions or concerns you may have
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          Respectfully,
-                        </div>
-                      </td>
-                    </tr>
-
-                    <tr>
-                      <td
-                        align="left"
-                        style="
-                          font-size: 0px;
-                          padding: 10px 25px;
-                          word-break: break-word;
-                        "
-                      >
-                        <div
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            Respectfully,
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td
+                          align="left"
                           style="
-                            font-family: helvetica;
-                            font-size: 20px;
-                            line-height: 1;
-                            text-align: left;
-                            color: #1b2352;
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
                           "
                         >
-                          CISA Continuous Phishing Program Adminstrator
-                        </div>
-                      </td>
-                    </tr>
+                          <div
+                            style="
+                              font-family: helvetica;
+                              font-size: 20px;
+                              line-height: 1;
+                              text-align: left;
+                              color: #1b2352;
+                            "
+                          >
+                            CISA Continuous Phishing Program Adminstrator
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
                   </table>
                 </div>
+                <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->
     </div>
   </body>
 </html>

--- a/tests/api/utils/test_aws.py
+++ b/tests/api/utils/test_aws.py
@@ -30,7 +30,6 @@ def test_ses(mock_client):
         bcc=[fake.email()],
         text=fake.paragraph(),
         html=fake.paragraph(),
-        attachments=["src/static/img/cisa_logo.png"],
         binary_attachments=[{"filename": "test", "data": fake.binary()}],
     )
 


### PR DESCRIPTION
Remove the CISA logo from all emails in Con-PCA

## 🗣 Description ##
Cisa logos were hardcoded in all emails delivered by con-pca. This change will have them removed.

## 💭 Motivation and context ##
This change was requested.

## 🧪 Testing ##
Test ran locally

## ✅ Checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
