### PR TITLE
fix issues with special characters in env vars

### DIFF
--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -15,13 +15,10 @@ service nginx start
 
 echo "Adding jobs to crontab"
 # Add cronjobs to crontab
+declare -p | grep -Ev '^declare -[[:alpha:]]*r' > /container.env
+(crontab -l ; echo "SHELL=/bin/bash") | crontab -
+(crontab -l ; echo "BASH_ENV=/container.env") | crontab -
 python manage.py crontab add
-
-# Copy environment variables into environment
-# so that cron jobs can access
-echo "$(env ; crontab -l)" | crontab -
-
-# Start cron service
 service cron start
 
 echo "Starting Con-PCA API"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Fix issues when special characters are in env vars and adding to crontab environment.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Crontab env vars are broken in staging environment.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Made sure env vars were loaded properly.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

