### PR TITLE
Fix stats performance due to non human queries

### DIFF
--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -55,6 +55,7 @@ def generate_cycle_stats(cycle, nonhuman=False):
         },
     }
     template_stats = {}
+    nonhuman_orgs = get_nonhuman_orgs()
     for target in cycle["targets"]:
         if target["template_uuid"] not in template_stats:
             template_stats[target["template_uuid"]] = {
@@ -70,7 +71,12 @@ def generate_cycle_stats(cycle, nonhuman=False):
             }
         timeline = target.get("timeline", [])
         if not nonhuman:
-            timeline = filter_nonhuman_events(timeline)
+            timeline = list(
+                filter(
+                    lambda x: x.get("details", {}).get("asn_org") not in nonhuman_orgs,
+                    timeline,
+                )
+            )
         sent = target.get("sent")
         sent_time = target.get("send_date")
         opened = get_event(timeline, "opened")
@@ -173,17 +179,6 @@ def get_event(timeline, event):
     if events:
         return min(events, key=lambda x: x["time"])
     return None
-
-
-def filter_nonhuman_events(timeline):
-    """Filter nonhuman events from timeline."""
-    nonhuman_orgs = get_nonhuman_orgs()
-    return list(
-        filter(
-            lambda x: x.get("details", {}).get("asn_org") not in nonhuman_orgs,
-            timeline,
-        )
-    )
 
 
 def get_nonhuman_orgs():


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Don't query non human orgs per target.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Performance improvement when generating stats.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Made sure stats still load.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
