### PR TITLE
Fix cisagov/action-lineage Configuration

### DIFF
--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -2,3 +2,4 @@
 lineage:
   skeleton:
     remote-url: https://github.com/cisagov/skeleton-docker.git
+version: '1'


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes the configuration file for [cisagov/action-lineage](https://github.com/cisagov/action-lineage) so that the project will receive automatic updates once more.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In https://github.com/cisagov/con-pca-api/pull/244 the `version` key was erroneously removed from the configuration file. This causes [cisagov/action-lineage](https://github.com/cisagov/action-lineage) to throw the following warning when trying to process the repository:

```console
Incompatible config version: None
```
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. The configuration file matches those successfully in use by other projects.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
