### PR TITLE
Revert "Bump pymongo from 3.12.1 to 4.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ gunicorn==20.1.0
 marshmallow==3.14.1
 mongomock==3.23.0
 Pillow==8.4.0
-pymongo==4.0
+pymongo==3.12.1
 PyPDF2==1.26.0
 requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ gunicorn==20.1.0
 marshmallow==3.14.1
 mongomock==3.23.0
 Pillow==8.4.0
-pymongo==3.12.1
+pymongo~=3.12.1
 PyPDF2==1.26.0
 requests==2.26.0


### PR DESCRIPTION
Reverts cisagov/con-pca-api#427

This new major update is causing issues with connection to DocumentDB.