### PR TITLE
DocumentDB Response Fix

### DIFF
--- a/src/api/manager.py
+++ b/src/api/manager.py
@@ -155,9 +155,11 @@ class Manager:
     def delete(self, document_id=None, params=None):
         """Delete item by object id."""
         if document_id:
-            return self.db.delete_one(self.document_query(document_id)).raw_result
+            self.db.delete_one(self.document_query(document_id))
+            return
         if params or params == {}:
-            return self.db.delete_many(params).raw_result
+            self.db.delete_many(params)
+            return
         raise Exception(
             "Either a document id or params must be supplied when deleting."
         )
@@ -169,7 +171,7 @@ class Manager:
         self.db.update_one(
             self.document_query(document_id),
             {"$set": self.load_data(data, partial=True)},
-        ).raw_result
+        )
 
     def update_many(self, params, data):
         """Update many items with params."""
@@ -200,19 +202,19 @@ class Manager:
         """Add item to list in document."""
         return self.db.update_one(
             self.document_query(document_id), {"$push": {field: data}}
-        ).raw_result
+        )
 
     def delete_from_list(self, document_id, field, data):
         """Delete item from list in document."""
         return self.db.update_one(
             self.document_query(document_id), {"$pull": {field: data}}
-        ).raw_result
+        )
 
     def update_in_list(self, document_id, field, data, params):
         """Update item in list from document."""
         query = self.document_query(document_id)
         query.update(params)
-        return self.db.update_one(query, {"$set": {field: data}}).raw_result
+        self.db.update_one(query, {"$set": {field: data}})
 
     def upsert(self, query, data):
         """Upsert documents into the database."""

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -81,7 +81,7 @@ def process_subscription(subscription):
 
 def update_task(subscription_id, task):
     """Update subsscription task."""
-    return subscription_manager.update_in_list(
+    subscription_manager.update_in_list(
         document_id=subscription_id,
         field="tasks.$",
         data=task,

--- a/src/api/views/customer_views.py
+++ b/src/api/views/customer_views.py
@@ -59,7 +59,8 @@ class CustomerView(MethodView):
                 ),
                 400,
             )
-        return jsonify(customer_manager.delete(document_id=customer_id))
+        customer_manager.delete(document_id=customer_id)
+        return jsonify({"success": True})
 
 
 class SectorIndustryView(MethodView):

--- a/src/api/views/landing_page_views.py
+++ b/src/api/views/landing_page_views.py
@@ -81,4 +81,5 @@ class LandingPageView(MethodView):
                 ),
                 400,
             )
-        return jsonify(landing_page_manager.delete(document_id=landing_page_id))
+        landing_page_manager.delete(document_id=landing_page_id)
+        return jsonify({"success": True})

--- a/src/api/views/sending_profile_views.py
+++ b/src/api/views/sending_profile_views.py
@@ -75,6 +75,5 @@ class SendingProfileView(MethodView):
                 ),
                 400,
             )
-        resp = sending_profile_manager.delete(document_id=sending_profile_id)
-        print(resp)
-        return jsonify(resp)
+        sending_profile_manager.delete(document_id=sending_profile_id)
+        return jsonify({"success": True})

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -112,7 +112,8 @@ class TemplateView(MethodView):
                 400,
             )
 
-        return jsonify(template_manager.delete(document_id=template_id))
+        template_manager.delete(document_id=template_id)
+        return jsonify({"success": True})
 
 
 class TemplateImportView(MethodView):


### PR DESCRIPTION
DocumentDB has other responses and no way to know what they are and how to serialize them

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Doesn't return raw result to client from deletion.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
DocumentDB started returning a separate field the Mongo typically doesn't returned that caused the following error.

```
TypeError: Object of type Timestamp is not JSON serializable
```

On investigation, it appeared that DocumentDB started responding with another key

```
'operationTime': Timestamp(1642088654, 1)
```

This now no longer returns the raw result in case additional fields are added.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Local.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
