### PR TITLE
fix: sending reports error

### DIFF
--- a/src/utils/notifications.py
+++ b/src/utils/notifications.py
@@ -139,7 +139,7 @@ class Notification:
         attachments = []
         if self.message_type in ["status_report", "cycle_report"]:
             filename = get_report_pdf(
-                self.cycle["_id"],
+                self.cycle,
                 self.message_type.split("_")[0],
                 reporting_password=self.subscription.get("reporting_password"),
                 nonhuman=nonhuman,


### PR DESCRIPTION
fixed `string indices must be integers` error when sending cycle reports

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.