### PR TITLE
Feature CPD-904: Include cycle_id in download file name

### DIFF
--- a/src/api/views/report_views.py
+++ b/src/api/views/report_views.py
@@ -70,7 +70,7 @@ class ReportPdfView(MethodView):
             return send_file(
                 filepath,
                 as_attachment=True,
-                download_name=f"{report_type}{cycle['_id']}.pdf",
+                download_name=f"{report_type}.pdf",
             )
         except Exception as e:
             logger.exception(

--- a/src/api/views/report_views.py
+++ b/src/api/views/report_views.py
@@ -68,7 +68,9 @@ class ReportPdfView(MethodView):
         try:
             logger.info(f"Sending file {filepath}")
             return send_file(
-                filepath, as_attachment=True, download_name=f"{report_type}.pdf"
+                filepath,
+                as_attachment=True,
+                download_name=f"{report_type}{cycle['_id']}.pdf",
             )
         except Exception as e:
             logger.exception(

--- a/src/utils/emails.py
+++ b/src/utils/emails.py
@@ -50,11 +50,17 @@ class Email:
         to_recipients=[],
         bcc_recipients=[],
         attachments=[],
+        **kwargs,
     ):
         """Send email."""
         if message_type == "safelisting_reminder":
             attachment_filename = secure_filename(
                 f"CISA_PCA_Safelisting_Information_{subscription_name}_{datetime.today().strftime('%m%d%Y')}.xlsx"
+            )
+        elif message_type == "status_report" or message_type == "cycle_report":
+            cycle_id = kwargs["cycle_id"]
+            attachment_filename = secure_filename(
+                f"CISA_PCA_{message_type}_{subscription_name}_{datetime.today().strftime('%m%d%Y')}_{cycle_id}.pdf"
             )
         else:
             attachment_filename = secure_filename(

--- a/src/utils/notifications.py
+++ b/src/utils/notifications.py
@@ -195,16 +195,29 @@ class Notification:
             from_address = config["REPORTING_FROM_ADDRESS"]
             if from_address:
                 email = Email(sending_profile)
-                email.send(
-                    from_email=from_address,
-                    to_recipients=addresses.get("to"),
-                    bcc_recipients=addresses.get("bcc"),
-                    message_type=self.message_type,
-                    subscription_name=self.subscription.get("name"),
-                    subject=report["subject"],
-                    body=report["html"],
-                    attachments=attachments,
-                )
+                if self.message_type in ["status_report", "cycle_report"]:
+                    email.send(
+                        from_email=from_address,
+                        to_recipients=addresses.get("to"),
+                        bcc_recipients=addresses.get("bcc"),
+                        message_type=self.message_type,
+                        subscription_name=self.subscription.get("name"),
+                        subject=report["subject"],
+                        body=report["html"],
+                        attachments=attachments,
+                        cycle_id=self.cycle["_id"],
+                    )
+                else:
+                    email.send(
+                        from_email=from_address,
+                        to_recipients=addresses.get("to"),
+                        bcc_recipients=addresses.get("bcc"),
+                        message_type=self.message_type,
+                        subscription_name=self.subscription.get("name"),
+                        subject=report["subject"],
+                        body=report["html"],
+                        attachments=attachments,
+                    )
 
                 self.add_notification_history(addresses, from_address)
         except Exception as e:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira ticket: https://cset.atlassian.net/browse/CPD-904

Frontend changes: https://github.com/cisagov/con-pca-web/pull/387

Added cycle_id to the filename string when downloaded. 

Added an optional argument so that cycle_id can be passed to the Email() function and then added to the filename string when reports are emailed.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Sometimes one wants to pull down and compare multiple cycle reports from the same subscription. If the reports have the exact same name, this is very inconvenient.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Please double check this one

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
