### PR TITLE
Bug: Aggregate Email stats not calculating correctly

### DIFF
--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -246,10 +246,20 @@ def generate_cycle_stats(cycle, targets, nonhuman=False):
 def get_rolling_averages(n_days):
     """Get total number of emails sent/clicked by the system over the last x days."""
     sent = target_manager.count(
-        {"sent_date": {"$gte": datetime.now() - timedelta(days=n_days)}}
+        {
+            "sent_date": {
+                "$gte": datetime.now() - timedelta(days=n_days),
+                "$lte": datetime.now(),
+            }
+        }
     )
     scheduled = target_manager.count(
-        {"send_date": {"$gte": datetime.now() - timedelta(days=n_days)}}
+        {
+            "send_date": {
+                "$gte": datetime.now() - timedelta(days=n_days),
+                "$lte": datetime.now(),
+            }
+        }
     )
     try:
         ratio = sent / scheduled
@@ -258,7 +268,10 @@ def get_rolling_averages(n_days):
     ratio = round(ratio, 4)
     clicked = target_manager.count(
         {
-            "sent_date": {"$gte": datetime.now() - timedelta(days=n_days)},
+            "sent_date": {
+                "$gte": datetime.now() - timedelta(days=n_days),
+                "$lte": datetime.now(),
+            },
             "timeline": {"$elemMatch": {"message": "clicked"}},
         }
     )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Added less-than-or-equal-to to the comparisons when calculating aggregate email statistics.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Aggregate email stats were not calculating correctly due to comparison with an open interval, which should have been a closed interval.  

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
