### PR TITLE
fix: enable restart on all continuous subscriptions

### DIFF
--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -88,9 +88,13 @@ def process_subscription(subscription):
         task["executed_date"] = datetime.utcnow()
         logger.info(f"Processing task {task}")
         try:
-            process_task(task, subscription, cycle) if task["scheduled_date"] > (
-                datetime.now(pytz.utc) - timedelta(days=2)
-            ) else None
+            # temporarily allow all previous end_cycle tasks to execute
+            if task["task_type"] == "end_cycle":
+                process_task(task, subscription, cycle)
+            else:
+                process_task(task, subscription, cycle) if task["scheduled_date"] > (
+                    datetime.now(pytz.utc) - timedelta(days=2)
+                ) else None
         except Exception as e:
             logger.exception(
                 f"An exception occurred performing {task['task_type']} task for {subscription['name']} subscription: {e}",


### PR DESCRIPTION
This PR is meant to temporarily allow end_cycle tasks to surpass the 2 day limit for task executions. Will be removed once production tasks relating to restarting continuous subscriptions are all complete

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
