### PR TITLE
Feature CPD-986: Combine time intervals charts

### DIFF
--- a/src/api/static/js/cycle.js
+++ b/src/api/static/js/cycle.js
@@ -226,22 +226,28 @@ function clickingUserTimelineChart() {
 
   dataset = [
     {
+      label: "All",
+      data: order_time_vals(decep_stats[9]["click_percentage_over_time"]),
+      borderColor: "#5a5b5d",
+      backgroundColor: "#5a5b5d",
+    },
+    {
       label: "Low",
       data: order_time_vals(decep_stats[6]["click_percentage_over_time"]),
-      borderColor: "#456799",
-      backgroundColor: "#456799",
+      borderColor: "#5e9732",
+      backgroundColor: "#5e9732",
     },
     {
       label: "Moderate",
       data: order_time_vals(decep_stats[7]["click_percentage_over_time"]),
-      borderColor: "#95433f",
-      backgroundColor: "#95433f",
+      borderColor: "#0078ae",
+      backgroundColor: "#0078ae",
     },
     {
       label: "High",
       data: order_time_vals(decep_stats[8]["click_percentage_over_time"]),
-      borderColor: "#839752",
-      backgroundColor: "#839752",
+      borderColor: "#c41230",
+      backgroundColor: "#c41230",
     },
   ];
 

--- a/src/api/templates/reports/cycle.html
+++ b/src/api/templates/reports/cycle.html
@@ -967,11 +967,6 @@
           TimeIntervalText();
         </script>
       </p>
-      <canvas id="click-rate-time-interval">
-        <script>
-          clickRateTimeIntervalChart();
-        </script>
-      </canvas>
       <canvas id="clicking-user-timeline">
         <script>
           clickingUserTimelineChart();

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -401,6 +401,52 @@ def get_deception_level_stats(stats: dict):
     }
     decp_lev_stats.append(high_deception_level)
 
+    all_deception_level = {
+        "deception_level": 14,
+        "sent_count": decp_lev_stats[0]["sent_count"]
+        + decp_lev_stats[1]["sent_count"]
+        + decp_lev_stats[2]["sent_count"]
+        + decp_lev_stats[3]["sent_count"]
+        + decp_lev_stats[4]["sent_count"]
+        + decp_lev_stats[5]["sent_count"],
+        "unique_clicks": decp_lev_stats[0]["unique_clicks"]
+        + decp_lev_stats[1]["unique_clicks"]
+        + decp_lev_stats[2]["unique_clicks"]
+        + decp_lev_stats[3]["unique_clicks"]
+        + decp_lev_stats[4]["unique_clicks"]
+        + decp_lev_stats[5]["unique_clicks"],
+        "total_clicks": decp_lev_stats[0]["total_clicks"]
+        + decp_lev_stats[1]["total_clicks"]
+        + decp_lev_stats[2]["total_clicks"]
+        + decp_lev_stats[3]["total_clicks"]
+        + decp_lev_stats[4]["total_clicks"]
+        + decp_lev_stats[5]["total_clicks"],
+        "user_reports": 0,
+        "unique_user_clicks": {
+            k: decp_lev_stats[0]["unique_user_clicks"].get(k, 0)
+            + decp_lev_stats[1]["unique_user_clicks"].get(k, 0)
+            + decp_lev_stats[2]["unique_user_clicks"].get(k, 0)
+            + decp_lev_stats[3]["unique_user_clicks"].get(k, 0)
+            + decp_lev_stats[4]["unique_user_clicks"].get(k, 0)
+            + decp_lev_stats[5]["unique_user_clicks"].get(k, 0)
+            for k in set(decp_lev_stats[0]["unique_user_clicks"])
+            | set(decp_lev_stats[1]["unique_user_clicks"])
+            | set(decp_lev_stats[2]["unique_user_clicks"])
+            | set(decp_lev_stats[3]["unique_user_clicks"])
+            | set(decp_lev_stats[4]["unique_user_clicks"])
+            | set(decp_lev_stats[5]["unique_user_clicks"])
+        },
+        "click_percentage_over_time": get_unique_click_over_time(
+            stats["1"]["clicked"]["diffs"]
+            + stats["2"]["clicked"]["diffs"]
+            + stats["3"]["clicked"]["diffs"]
+            + stats["4"]["clicked"]["diffs"]
+            + stats["5"]["clicked"]["diffs"]
+            + stats["6"]["clicked"]["diffs"]
+        ),
+    }
+    decp_lev_stats.append(all_deception_level)
+
     return decp_lev_stats
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira Ticket: https://cset.atlassian.net/browse/CPD-986

Consolidated the data from two charts in the cycle report 'Time Intervals' section to one chart, adding the 'all' category.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The two different graphs were confusing for users. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

