### PR TITLE
Feature CPD-1021: Remove small groups from user group stats csv

### DIFF
--- a/src/api/templates/reports/cycle.html
+++ b/src/api/templates/reports/cycle.html
@@ -1366,6 +1366,11 @@
         <li class="indent">user_group_stats.csv</li>
       </ul>
       <p class="indent">
+        Note that groups with five or fewer individuals will not be represented
+        in the user_group_stats.csv file. This is to protect the anonymity of
+        participants.
+      </p>
+      <p class="indent">
         You can access the CSV files attached to this report by following these
         steps:
       </p>

--- a/src/utils/reports.py
+++ b/src/utils/reports.py
@@ -253,6 +253,7 @@ def _user_group_stats_csv(cycle: dict) -> Tuple[str, List[str], List[Any]]:
             "All Clicked": t["clicked"]["count"],
         }
         for t in stats["target_stats"]
+        if t["sent"]["count"] > 5
     ]
     headers = list(data[0].keys())
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira Ticket: https://cset.atlassian.net/browse/CPD-1021

Add a condition to the _user_group_stats_csv function to only show the row if there were more than 5 emails sent.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

For privacy reasons, we do not want to display user group data if there are five or fewer people in the group.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

