### PR TITLE
Fix https://github.com/cisagov/con-pca-api/pull/830: Cover the Case of no qualifying groups

### DIFF
--- a/src/utils/reports.py
+++ b/src/utils/reports.py
@@ -255,8 +255,13 @@ def _user_group_stats_csv(cycle: dict) -> Tuple[str, List[str], List[Any]]:
         for t in stats["target_stats"]
         if t["sent"]["count"] > 5
     ]
+    if len(data) == 0:
+        data = [
+            {
+                "Message": "To protect the anonymity of participants, data can only be displayed for groups with over 5 members. This cycle does not have any qualifying groups.",
+            }
+        ]
     headers = list(data[0].keys())
-
     return "user_group_stats.csv", headers, data
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Previous PR: https://github.com/cisagov/con-pca-api/pull/830

Added logic to cover the edge case of when no groups have more than 5 participants. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Testing revealed that the previous feature was causing cycle reports to fail if there were no qualifying groups.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

