### PR TITLE
Feature CPD-1020: Next cycle templates

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -61,8 +61,10 @@ from api.views.report_views import (
 )
 from api.views.sending_profile_views import SendingProfilesView, SendingProfileView
 from api.views.subscription_views import (
+    SubscriptionCurrentTemplatesView,
     SubscriptionHeaderView,
     SubscriptionLaunchView,
+    SubscriptionNextTemplatesView,
     SubscriptionSafelistExportView,
     SubscriptionSafelistSendView,
     SubscriptionsView,
@@ -138,6 +140,11 @@ rules = [
         SubscriptionSafelistExportView,
     ),
     ("/subscription/<subscription_id>/safelist/send/", SubscriptionSafelistSendView),
+    (
+        "/subscription/<subscription_id>/templates/current/",
+        SubscriptionCurrentTemplatesView,
+    ),
+    ("/subscription/<subscription_id>/templates/next/", SubscriptionNextTemplatesView),
     # Tag Views
     ("/tags/", TagsView),
     # Template Views

--- a/src/api/schemas/subscription_schema.py
+++ b/src/api/schemas/subscription_schema.py
@@ -93,6 +93,7 @@ class SubscriptionSchema(BaseSchema):
     )
     target_email_list = fields.List(fields.Nested(SubscriptionTargetSchema))
     templates_selected = fields.List(fields.Str())
+    next_templates = fields.List(fields.Str())
     continuous_subscription = fields.Bool()
     buffer_time_minutes = fields.Integer()
     cycle_length_minutes = fields.Integer()

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -208,15 +208,23 @@ def end_cycle(subscription, cycle):
     if subscription.get("continuous_subscription"):
         stop_subscription(str(subscription["_id"]))
         # randomize templates between cycles
-        templates = [
-            t
-            for t in template_manager.all({"retired": False})
-            if t not in subscription["templates_selected"]
-        ]
-        templates_selected = sum(select_templates(templates), [])
-        start_subscription(
-            str(subscription["_id"]), templates_selected=templates_selected
-        )
+        if subscription.get("next_templates"):
+            start_subscription(
+                str(subscription["_id"]),
+                templates_selected=subscription["next_templates"],
+            )
+
+        else:
+            templates = [
+                t
+                for t in template_manager.all({"retired": False})
+                if t not in subscription["templates_selected"]
+            ]
+            templates_selected = sum(select_templates(templates), [])
+            start_subscription(
+                str(subscription["_id"]), templates_selected=templates_selected
+            )
+
     else:
         stop_subscription(str(subscription["_id"]))
         Notification("subscription_stopped", subscription, cycle).send()
@@ -231,12 +239,18 @@ def safelisting_reminder(subscription, cycle):
         fields=["subject", "deception_score"],
     )
 
+    next_templates = template_manager.all(
+        params={"_id": {"$in": subscription["next_templates"]}},
+        fields=["subject", "deception_score"],
+    )
+
     filepath = generate_safelist_file(
         subscription_id=subscription["_id"],
         phish_header=cycle["phish_header"],
         domains=[sp["from_address"].split("@")[1] for sp in sending_profiles],
         ips=[sp["sending_ips"] for sp in sending_profiles],
         templates=templates,
+        next_templates=next_templates,
         reporting_password=subscription["reporting_password"],
         simulation_url=subscription.get("landing_domain", ""),  # simulated phishing url
     )

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -333,3 +333,33 @@ class SubscriptionSafelistSendView(MethodView):
         )
 
         return jsonify({"success": "Safelisting information email sent."})
+
+
+class SubscriptionCurrentTemplatesView(MethodView):
+    """Get the current templates for a given subscription."""
+
+    def get(self, subscription_id):
+        """Get test results for a subscription."""
+        template_ids = subscription_manager.get(
+            document_id=subscription_id, fields=["templates_selected"]
+        ).get("templates_selected", [])
+        templates = template_manager.all(
+            params={"_id": {"$in": template_ids}},
+            fields=["subject"],
+        )
+        return jsonify([t["subject"] for t in templates if "subject" in t])
+
+
+class SubscriptionNextTemplatesView(MethodView):
+    """Get the next templates for a given subscription."""
+
+    def get(self, subscription_id):
+        """Get test results for a subscription."""
+        template_ids = subscription_manager.get(
+            document_id=subscription_id, fields=["next_templates"]
+        ).get("next_templates", [])
+        templates = template_manager.all(
+            params={"_id": {"$in": template_ids}},
+            fields=["subject"],
+        )
+        return jsonify([t["subject"] for t in templates if "subject" in t])

--- a/src/utils/safelist.py
+++ b/src/utils/safelist.py
@@ -17,6 +17,7 @@ def generate_safelist_file(
     domains,
     ips,
     templates,
+    next_templates,
     reporting_password,
     simulation_url,
 ):
@@ -69,8 +70,12 @@ def generate_safelist_file(
             ws[f"B{ip_start + i}"].font = regular_font
         ws.merge_cells(f"A{ip_start}:A{ip_start + len(ips) - 1}")
 
-    # Templates
-    template_start = 3 + len(domains) + (1 if not ips else len(ips)) + 1
+    # Current Cycle Templates
+    current_label_start = 3 + len(domains) + (1 if not ips else len(ips)) + 1
+    ws[f"A{current_label_start}"] = "Current Cycle Templates:"
+    ws[f"A{current_label_start}"].font = header_font
+
+    template_start = current_label_start + 2
     ws[f"A{template_start}"] = "Template Subject"
     ws[f"B{template_start}"] = "Deception Level"
     ws[f"A{template_start}"].font = header_font
@@ -82,6 +87,24 @@ def generate_safelist_file(
             template["deception_score"]
         ).title()
         ws[f"B{template_start + i + 1}"].font = regular_font
+
+    # Next Cycle Templates
+    next_label_start = current_label_start + len(templates) + 4
+    ws[f"A{next_label_start}"] = "Next Cycle Templates:"
+    ws[f"A{next_label_start}"].font = header_font
+
+    next_template_start = next_label_start + 2
+    ws[f"A{next_template_start}"] = "Template Subject"
+    ws[f"B{next_template_start}"] = "Deception Level"
+    ws[f"A{next_template_start}"].font = header_font
+    ws[f"B{next_template_start}"].font = header_font
+    for i, template in enumerate(next_templates):
+        ws[f"A{next_template_start + i + 1}"] = template["subject"]
+        ws[f"A{next_template_start + i + 1}"].font = regular_font
+        ws[f"B{next_template_start + i + 1}"] = get_deception_level(
+            template["deception_score"]
+        ).title()
+        ws[f"B{next_template_start + i + 1}"].font = regular_font
 
     # Expand columns in workbook
     for cells in ws.columns:

--- a/src/utils/safelist.py
+++ b/src/utils/safelist.py
@@ -8,7 +8,10 @@ from openpyxl.utils import get_column_letter
 from openpyxl.workbook import Workbook
 
 # cisagov Libraries
+from api.manager import SubscriptionManager
 from utils.templates import get_deception_level
+
+subscription_manager = SubscriptionManager()
 
 
 def generate_safelist_file(
@@ -89,22 +92,24 @@ def generate_safelist_file(
         ws[f"B{template_start + i + 1}"].font = regular_font
 
     # Next Cycle Templates
-    next_label_start = current_label_start + len(templates) + 4
-    ws[f"A{next_label_start}"] = "Next Cycle Templates:"
-    ws[f"A{next_label_start}"].font = header_font
+    subscription = subscription_manager.get(subscription_id)
+    if subscription.get("continuous_subscription"):
+        next_label_start = current_label_start + len(templates) + 4
+        ws[f"A{next_label_start}"] = "Next Cycle Templates:"
+        ws[f"A{next_label_start}"].font = header_font
 
-    next_template_start = next_label_start + 2
-    ws[f"A{next_template_start}"] = "Template Subject"
-    ws[f"B{next_template_start}"] = "Deception Level"
-    ws[f"A{next_template_start}"].font = header_font
-    ws[f"B{next_template_start}"].font = header_font
-    for i, template in enumerate(next_templates):
-        ws[f"A{next_template_start + i + 1}"] = template["subject"]
-        ws[f"A{next_template_start + i + 1}"].font = regular_font
-        ws[f"B{next_template_start + i + 1}"] = get_deception_level(
-            template["deception_score"]
-        ).title()
-        ws[f"B{next_template_start + i + 1}"].font = regular_font
+        next_template_start = next_label_start + 2
+        ws[f"A{next_template_start}"] = "Template Subject"
+        ws[f"B{next_template_start}"] = "Deception Level"
+        ws[f"A{next_template_start}"].font = header_font
+        ws[f"B{next_template_start}"].font = header_font
+        for i, template in enumerate(next_templates):
+            ws[f"A{next_template_start + i + 1}"] = template["subject"]
+            ws[f"A{next_template_start + i + 1}"].font = regular_font
+            ws[f"B{next_template_start + i + 1}"] = get_deception_level(
+                template["deception_score"]
+            ).title()
+            ws[f"B{next_template_start + i + 1}"].font = regular_font
 
     # Expand columns in workbook
     for cells in ws.columns:

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -17,7 +17,7 @@ from api.manager import (
     TargetManager,
     TemplateManager,
 )
-from utils.templates import get_deception_level
+from utils.templates import get_deception_level, select_templates
 
 # from utils.time import get_yearly_minutes
 
@@ -95,6 +95,15 @@ def start_subscription(subscription_id, templates_selected=[]):
 
     if templates_selected:
         update_data["templates_selected"] = templates_selected
+
+    next_templates = [
+        t
+        for t in template_manager.all({"retired": False})
+        if t not in templates_selected
+    ]
+    next_templates_selected = sum(select_templates(next_templates), [])
+    if next_templates_selected:
+        update_data["next_templates"] = next_templates_selected
 
     subscription_manager.update(document_id=subscription_id, data=update_data)
     cycle_manager.update(document_id=cycle_id, data=cycle)

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -206,15 +206,17 @@ def get_initial_tasks(subscription, cycle):
         else start_date + timedelta(minutes=cycle_minutes),
     }
 
+    if subscription.get("continuous_subscription"):
+        task_types["safelisting_reminder"] = start_date
+        +timedelta(minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0)))
+
     cycle_days = cycle_minutes / 60 / 24
     if cycle_days >= 30:
         task_types["thirty_day_reminder"] = end_date - timedelta(days=30)
     if cycle_days >= 15:
         task_types["fifteen_day_reminder"] = end_date - timedelta(days=15)
-        task_types["safelisting_reminder"] = end_date - timedelta(days=15)
     if cycle_days >= 5:
         task_types["five_day_reminder"] = end_date - timedelta(days=5)
-        task_types["safelisting_reminder"] = end_date - timedelta(days=5)
 
     tasks = []
     for task_type, scheduled_date in task_types.items():

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -208,7 +208,7 @@ def get_initial_tasks(subscription, cycle):
 
     if subscription.get("continuous_subscription"):
         task_types["safelisting_reminder"] = start_date
-        +timedelta(minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0)))
+        +timedelta(minutes=(cycle_minutes))
 
     cycle_days = cycle_minutes / 60 / 24
     if cycle_days >= 30:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira ticket: https://cset.atlassian.net/browse/CPD-1020

Backend changes: https://github.com/cisagov/con-pca-web/pull/429

Created a new subscription database field called 'next_templates'. The field will be populated gracefully as new cycles begin, or a safelisting report is requested. When a new cycle is started, the templates from the 'next_templates' field are moved into the 'templates_selected' field, and the 'next_templates' field is randomized with new templates.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Request from the client. Some customers want to be able to know the templates that will be used during the next cycle to aid in their safelisting practices.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.
