### PR TITLE
Feature CPD-1035: Buffer time updates

### DIFF
--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -1,6 +1,6 @@
 """Scripts to run when application starts."""
 # Standard Python Libraries
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import os
 
@@ -147,9 +147,18 @@ def restart_subscriptions():
     for subscription in subscriptions:
         cycles = cycle_manager.all(params={"subscription_id": subscription["_id"]})
         # get the most recent cycle
-        end_date = sorted(cycles, key=lambda x: x["end_date"], reverse=True)[0][
-            "end_date"
-        ]
+        end_date = sorted(
+            cycles,
+            key=lambda x: x["start_date"]
+            + timedelta(
+                minutes=(
+                    subscription.get("cycle_length_minutes", 0)
+                    + subscription.get("cooldown_minutes", 0)
+                    + subscription.get("buffer_time_minutes", 0)
+                )
+            ),
+            reverse=True,
+        )[0]["end_date"]
 
         now = pytz.utc.localize(datetime.now())
 

--- a/src/api/schemas/subscription_schema.py
+++ b/src/api/schemas/subscription_schema.py
@@ -52,6 +52,7 @@ class SubscriptionTasksSchema(Schema):
                 "five_day_reminder",
                 "safelisting_reminder",
                 "end_cycle",
+                "start_next_cycle",
             ]
         )
     )

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -156,6 +156,7 @@ def process_task(task, subscription, cycle):
         "cycle_report": cycle_report,
         # "yearly_report": yearly_report,
         "end_cycle": end_cycle,
+        "start_next_cycle": end_cycle,
         "thirty_day_reminder": thirty_day_reminder,
         "fifteen_day_reminder": fifteen_day_reminder,
         "five_day_reminder": five_day_reminder,

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -66,6 +66,8 @@ class SubscriptionsView(MethodView):
                 "status",
                 "start_date",
                 "cycle_length_minutes",
+                "cooldown_minutes",
+                "buffer_time_minutes",
                 "active",
                 "archived",
                 "primary_contact",

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -196,7 +196,7 @@ def get_initial_tasks(subscription, cycle):
             minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0))
         )
     else:
-        task_types["end_cycle"] = start_date + timedelta(minutes=(cycle_minutes))
+        task_types["end_cycle"] = start_date + timedelta(minutes=(cycle_minutes + 15))
 
     cycle_days = cycle_minutes / 60 / 24
     if cycle_days >= 30:

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -189,13 +189,14 @@ def get_initial_tasks(subscription, cycle):
         "status_report": start_date + timedelta(minutes=report_minutes),
         "cycle_report": start_date + timedelta(minutes=cycle_minutes),
         # "yearly_report": start_date + timedelta(minutes=yearly_minutes),
-        "end_cycle": start_date
-        + timedelta(
-            minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0))
-        )
-        if subscription.get("continuous_subscription")
-        else start_date + timedelta(minutes=cycle_minutes),
     }
+
+    if subscription.get("continuous_subscription"):
+        task_types["start_next_cycle"] = start_date
+        +timedelta(minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0)))
+    else:
+        task_types["end_cycle"] = start_date
+        +timedelta(minutes=(cycle_minutes))
 
     cycle_days = cycle_minutes / 60 / 24
     if cycle_days >= 30:

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -192,11 +192,11 @@ def get_initial_tasks(subscription, cycle):
     }
 
     if subscription.get("continuous_subscription"):
-        task_types["start_next_cycle"] = start_date
-        +timedelta(minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0)))
+        task_types["start_next_cycle"] = start_date + timedelta(
+            minutes=(cycle_minutes + subscription.get("buffer_time_minutes", 0))
+        )
     else:
-        task_types["end_cycle"] = start_date
-        +timedelta(minutes=(cycle_minutes))
+        task_types["end_cycle"] = start_date + timedelta(minutes=(cycle_minutes))
 
     cycle_days = cycle_minutes / 60 / 24
     if cycle_days >= 30:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira Ticket: https://cset.atlassian.net/browse/CPD-1035

Front-end changes: https://github.com/cisagov/con-pca-web/pull/428

Make sure that automatic restart of overdue subscriptions factors in buffer time. 

Buffer time should only apply to continuous subscriptions.

The end_cycle tack is renamed to 'start_next_cycle' for new cycles of continuous subscriptions.  

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Fix the oversight in the automated restart of overdue subscriptions, and make the cycle process clearer for end users.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

