### PR TITLE
Fix: Next cycle templates and cycle tasks fix

### DIFF
--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -133,7 +133,7 @@ def populate_cycle_tasks():
     )
     for cycle in active_cycles:
         subscription = subscription_manager.get(document_id=cycle["subscription_id"])
-        if not cycle.get("tasks"):
+        if cycle.get("tasks", []) == [] and subscription.get("tasks", []) != []:
             cycle_manager.update(
                 document_id=cycle["_id"],
                 data={

--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -133,7 +133,7 @@ def populate_cycle_tasks():
     )
     for cycle in active_cycles:
         subscription = subscription_manager.get(document_id=cycle["subscription_id"])
-        if cycle.get("tasks", []) == [] and subscription.get("tasks", []) != []:
+        if not cycle.get("tasks") and subscription.get("tasks"):
             cycle_manager.update(
                 document_id=cycle["_id"],
                 data={

--- a/src/api/schemas/cycle_schema.py
+++ b/src/api/schemas/cycle_schema.py
@@ -50,7 +50,7 @@ class CycleSchema(BaseSchema):
     send_by_date = DateTimeField()
     active = fields.Bool()
     target_count = fields.Integer()
-    tasks = fields.List(fields.Nested(CycleTasksSchema))
+    tasks = fields.List(fields.Nested(CycleTasksSchema), required=False)
     dirty_stats = fields.Bool()
     stats = fields.Nested(CycleStatsSchema)
     nonhuman_stats = fields.Nested(CycleStatsSchema)

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -209,7 +209,7 @@ def end_cycle(subscription, cycle):
     if subscription.get("continuous_subscription"):
         stop_subscription(str(subscription["_id"]))
         # randomize templates between cycles
-        if subscription.get("next_templates", []) != []:
+        if subscription.get("next_templates"):
             start_subscription(
                 str(subscription["_id"]),
                 templates_selected=subscription["next_templates"],

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -209,7 +209,7 @@ def end_cycle(subscription, cycle):
     if subscription.get("continuous_subscription"):
         stop_subscription(str(subscription["_id"]))
         # randomize templates between cycles
-        if subscription.get("next_templates"):
+        if subscription.get("next_templates", []) != []:
             start_subscription(
                 str(subscription["_id"]),
                 templates_selected=subscription["next_templates"],

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -271,7 +271,7 @@ class SubscriptionSafelistExportView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if subscription.get("next_templates", []) == []:
+        if subscription.get("next_templates"):
             update_data = {}
             next_templates = [
                 t
@@ -336,7 +336,7 @@ class SubscriptionSafelistSendView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if subscription.get("next_templates", []) == []:
+        if subscription.get("next_templates"):
             update_data = {}
             next_templates = [
                 t

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -271,7 +271,7 @@ class SubscriptionSafelistExportView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if not subscription.get("next_templates"):
+        if subscription.get("next_templates", []) == []:
             update_data = {}
             next_templates = [
                 t
@@ -334,7 +334,7 @@ class SubscriptionSafelistSendView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if not subscription.get("next_templates"):
+        if subscription.get("next_templates", []) == []:
             update_data = {}
             next_templates = [
                 t

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -282,9 +282,11 @@ class SubscriptionSafelistExportView(MethodView):
             if next_templates_selected:
                 update_data["next_templates"] = next_templates_selected
             subscription_manager.update(document_id=subscription_id, data=update_data)
+        else:
+            next_templates_selected = subscription.get("next_templates", [])
 
         data["next_templates"] = template_manager.all(
-            params={"_id": {"$in": subscription.get("next_templates", [])}},
+            params={"_id": {"$in": next_templates_selected}},
             fields=["subject", "deception_score"],
         )
 
@@ -345,9 +347,11 @@ class SubscriptionSafelistSendView(MethodView):
             if next_templates_selected:
                 update_data["next_templates"] = next_templates_selected
             subscription_manager.update(document_id=subscription_id, data=update_data)
+        else:
+            next_templates_selected = subscription.get("next_templates", [])
 
         data["next_templates"] = template_manager.all(
-            params={"_id": {"$in": subscription.get("next_templates", [])}},
+            params={"_id": {"$in": next_templates_selected}},
             fields=["subject", "deception_score"],
         )
 

--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -271,7 +271,7 @@ class SubscriptionSafelistExportView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if subscription.get("next_templates"):
+        if not subscription.get("next_templates"):
             update_data = {}
             next_templates = [
                 t
@@ -336,7 +336,7 @@ class SubscriptionSafelistSendView(MethodView):
         data = request.json
 
         # Randomize Next templates if they do not already exist
-        if subscription.get("next_templates"):
+        if not subscription.get("next_templates"):
             update_data = {}
             next_templates = [
                 t


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Fixing a adding an else statement

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Let the program correctly generate next cycle templates and transfer tasks from the subscription to the cycle.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ x] This PR has an informative and human-readable title.
- [ x] Changes are limited to a single goal - *eschew scope creep!*
- [ x] All relevant type-of-change labels have been added.
- [ x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ x] All new and existing tests pass.
