### PR TITLE
fix: remove populate cycle tasks

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -18,7 +18,6 @@ from api.initialize import (
     initialize_nonhumans,
     initialize_recommendations,
     initialize_templates,
-    populate_cycle_tasks,
     populate_stakeholder_shortname,
     reset_dirty_stats,
 )
@@ -207,7 +206,7 @@ with app.app_context():
     initialize_nonhumans()
     reset_dirty_stats()
     populate_stakeholder_shortname()
-    populate_cycle_tasks()
+    # populate_cycle_tasks()
     # restart_subscriptions()
 
 
@@ -266,12 +265,4 @@ def load_dummy_data():
     """Load test data to db."""
     initialize_templates()
     load_test_data()
-    logger.info("Success.")
-
-
-@app.cli.command("transform-data")
-def populate_new_fields_with_data():
-    """Add default data directly to the database for new required fields."""
-    populate_stakeholder_shortname()
-    populate_cycle_tasks()
     logger.info("Success.")

--- a/src/api/schemas/cycle_schema.py
+++ b/src/api/schemas/cycle_schema.py
@@ -30,6 +30,7 @@ class CycleTasksSchema(Schema):
                 "fifteen_day_reminder",
                 "five_day_reminder",
                 "safelisting_reminder",
+                "start_next_cycle",
                 "end_cycle",
             ]
         )


### PR DESCRIPTION
remove due to the following timeout error:
`[2022-11-17 03:12:03 +0000] [11] [CRITICAL] WORKER TIMEOUT (pid:27)`

## 🗣 Description ##
also fix: 
```
marshmallow.exceptions.ValidationError:
{'tasks': {3: {'task_type': ['Must be one of:
start_subscription_email, status_report,
cycle_report, yearly_report, thirty_day_reminder,
fifteen_day_reminder, five_day_reminder,
safelisting_reminder, end_cycle.']}}}
```

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

