### PR TITLE
Revert: CPD-1031

### DIFF
--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -209,15 +209,22 @@ def end_cycle(subscription, cycle):
     if subscription.get("continuous_subscription"):
         stop_subscription(str(subscription["_id"]))
         # randomize templates between cycles
-        templates = [
-            t
-            for t in template_manager.all({"retired": False})
-            if t not in subscription["templates_selected"]
-        ]
-        templates_selected = sum(select_templates(templates), [])
-        start_subscription(
-            str(subscription["_id"]), templates_selected=templates_selected
-        )
+        if subscription.get("next_templates"):
+            start_subscription(
+                str(subscription["_id"]),
+                templates_selected=subscription["next_templates"],
+            )
+
+        else:
+            templates = [
+                t
+                for t in template_manager.all({"retired": False})
+                if t not in subscription["templates_selected"]
+            ]
+            templates_selected = sum(select_templates(templates), [])
+            start_subscription(
+                str(subscription["_id"]), templates_selected=templates_selected
+            )
     else:
         stop_subscription(str(subscription["_id"]))
         Notification("subscription_stopped", subscription, cycle).send()
@@ -232,12 +239,18 @@ def safelisting_reminder(subscription, cycle):
         fields=["subject", "deception_score"],
     )
 
+    next_templates = template_manager.all(
+        params={"_id": {"$in": subscription["next_templates"]}},
+        fields=["subject", "deception_score"],
+    )
+
     filepath = generate_safelist_file(
         subscription_id=subscription["_id"],
         phish_header=cycle["phish_header"],
         domains=[sp["from_address"].split("@")[1] for sp in sending_profiles],
         ips=[sp["sending_ips"] for sp in sending_profiles],
         templates=templates,
+        next_templates=next_templates,
         reporting_password=subscription["reporting_password"],
         simulation_url=subscription.get("landing_domain", ""),  # simulated phishing url
     )

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -89,6 +89,7 @@ def start_subscription(subscription_id, templates_selected=[]):
 
     update_data = {
         "status": "running",
+        "tasks": tasks,
     }
 
     cycle["tasks"] = tasks


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If populate_cycle_stats doesn't work due to timeout error
`[2022-11-17 03:12:03 +0000] [11] [CRITICAL] WORKER TIMEOUT (pid:27)`
then no tasks will run because part of CPD-1031 was moving task processing to be done off of the cycle, rather than the subscription. This PR reverts those changes, having the tasks_job check the subscriptions once again until we can be sure that the migration of tasks data from the subscriptions to the cycles was successful.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x]  This PR has an informative and human-readable title.
- [x]  Changes are limited to a single goal - *eschew scope creep!*

- [x]  All relevant type-of-change labels have been added.
- [x]  I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.

- [x]  All new and existing tests pass.
