### PR TITLE
Feature: Historical task data v2

### DIFF
--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -140,22 +140,6 @@ def reset_dirty_stats():
         )
 
 
-def populate_cycle_tasks():
-    """Populate the cycle tasks from the subscription tasks."""
-    active_cycles = cycle_manager.all(
-        params={"active": True}, fields=["_id", "tasks", "subscription_id"]
-    )
-    for cycle in active_cycles:
-        subscription = subscription_manager.get(document_id=cycle["subscription_id"])
-        if not cycle.get("tasks") and subscription.get("tasks"):
-            cycle_manager.update(
-                document_id=cycle["_id"],
-                data={
-                    "tasks": subscription.get("tasks"),
-                },
-            )
-
-
 def restart_subscriptions():
     """
     Restart all overdue continuous Subscriptions.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -206,7 +206,6 @@ with app.app_context():
     initialize_nonhumans()
     reset_dirty_stats()
     populate_stakeholder_shortname()
-    # populate_cycle_tasks()
     # restart_subscriptions()
 
 

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -106,6 +106,12 @@ def process_subscription(subscription):
         document_id=subscription["_id"], data={"processing": False}, update=False
     )
 
+    cycle = cycle_manager.get(
+        filter_data={
+            "subscription_id": str(subscription["_id"]),
+            "active": True,
+        }
+    )
     cycle_manager.update(
         document_id=cycle["_id"],
         data={

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -106,6 +106,13 @@ def process_subscription(subscription):
         document_id=subscription["_id"], data={"processing": False}, update=False
     )
 
+    cycle_manager.update(
+        document_id=cycle["_id"],
+        data={
+            "tasks": subscription.get("tasks"),
+        },
+    )
+
 
 def update_task(subscription_id, task):
     """Update subscription task."""


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since the populate_cycle_tasks initialize script was timing out in production, we will move the data over to the cycles incrementally, rather than a singular migration. Tasks processing will still happen from the subscription, and the data will just be copied over each time a subscription is processed. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

