### PR TITLE
Fix: Temporarily setting to only one status report per cycle

### DIFF
--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -133,15 +133,16 @@ def update_task(subscription_id, task):
 def add_new_task(subscription, cycle, task):
     """Add new subscription task."""
     scheduled = task["scheduled_date"]
-    report_minutes = subscription["report_frequency_minutes"]
+    # report_minutes = subscription["report_frequency_minutes"]
     cycle_minutes = (
         subscription["cycle_length_minutes"] + subscription["cooldown_minutes"]
     )
     # yearly_minutes = get_yearly_minutes()
     new_date = {
-        "status_report": scheduled + timedelta(minutes=report_minutes),
+        # "status_report": scheduled + timedelta(minutes=report_minutes),
         # "yearly_report": scheduled + timedelta(minutes=yearly_minutes),
-        "end_cycle": scheduled + timedelta(minutes=cycle_minutes),
+        "end_cycle": scheduled
+        + timedelta(minutes=cycle_minutes),
     }.get(task["task_type"])
     if new_date:
         task = {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Avoid back to back status reports being sent bug. Will be replaced with logic to preschedule all cycle tasks at start of cycle.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.


