### PR TITLE
Fix: reset processing on all subscriptions to false on initialize

### DIFF
--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -130,7 +130,7 @@ def _populate_stakeholder_shortname():
 
 
 def _reset_processing():
-    """Populate the stakeholder_shortname field with the same name as customer_identifier if empty."""
+    """Set processing to false for all subscriptions."""
     subscriptions = subscription_manager.all()
     for subscription in subscriptions:
         subscription_manager.update(

--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -129,6 +129,18 @@ def _populate_stakeholder_shortname():
             )
 
 
+def _reset_processing():
+    """Populate the stakeholder_shortname field with the same name as customer_identifier if empty."""
+    subscriptions = subscription_manager.all()
+    for subscription in subscriptions:
+        subscription_manager.update(
+            document_id=subscription["_id"],
+            data={
+                "processing": False,
+            },
+        )
+
+
 def _restart_logging_ttl_index(ttl_in_seconds=345600):
     """Create the ttl index."""
     try:
@@ -227,4 +239,5 @@ def initialization_tasks():
         _initialize_nonhumans()
         _reset_dirty_stats()
         _populate_stakeholder_shortname()
+        _reset_processing()
         # restart_subscriptions()

--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -131,8 +131,13 @@ def _populate_stakeholder_shortname():
 
 def _reset_processing():
     """Set processing to false for all subscriptions."""
-    subscriptions = subscription_manager.all()
+    subscriptions = subscription_manager.all(
+        params={"processing": True}, fields=["name", "processing"]
+    )
     for subscription in subscriptions:
+        logger.info(
+            f"Resetting processing for subscription {subscription.get('name')} from {subscription.get('processing')} to False."
+        )
         subscription_manager.update(
             document_id=subscription["_id"],
             data={


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Reset processing on all subscriptions to false on initialize

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Fix the tasks errors

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

