### PR TITLE
fix: initialize template oid fields

### DIFF
--- a/src/api/initialize.py
+++ b/src/api/initialize.py
@@ -267,7 +267,9 @@ def _duplicate_oid_fields():
                         f"Updating {oid_name} for template {template.get('name')} to match {template.get(id_name)}."
                     )
                     update_data[oid_name] = ObjectId(template.get(id_name, None))
-                template_manager.update(document_id=template["_id"], data=update_data)
+                    template_manager.update(
+                        document_id=template["_id"], data=update_data
+                    )
 
     # Targets
     targets = target_manager.all(


### PR DESCRIPTION
Fix for initialize oid field func

## 🗣 Description ##
From cloudwatch logs in sandbox:
```
KeyError: 'name'
"$regex": f"^{re.escape(data[unique_field].strip())}$",
File "/var/www/api/manager.py", line 225, in update
template_manager.update(document_id=template["_id"], data=update_data)
File "/var/www/api/initialize.py", line 270, in _duplicate_oid_fields
_duplicate_oid_fields()
File "/var/www/api/initialize.py", line 401, in initialization_tasks
initialization_tasks()
File "/var/www/api/main.py", line 235, in <module>
```

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
