### PR TITLE
Fix: Nonetype object not subscriptable staging bug

### DIFF
--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -117,12 +117,13 @@ def process_subscription(subscription):
             "active": True,
         }
     )
-    cycle_manager.update(
-        document_id=cycle["_id"],
-        data={
-            "tasks": subscription.get("tasks"),
-        },
-    )
+    if cycle:
+        cycle_manager.update(
+            document_id=cycle["_id"],
+            data={
+                "tasks": subscription.get("tasks"),
+            },
+        )
 
 
 def update_task(subscription_id, task):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira ticket: https://cset.atlassian.net/browse/CPD-1085
NoneType object is not subscriptable due to "cycle['id']"

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Bug fix

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

