### PR TITLE
Fix: Next templates bug

### DIFF
--- a/src/api/views/subscription_views.py
+++ b/src/api/views/subscription_views.py
@@ -710,14 +710,9 @@ class SubscriptionLaunchView(MethodView):
         subscription = subscription_manager.get(
             document_id=subscription_id, fields=["next_templates"]
         )
-        if subscription.get("next_templates"):
-            next_templates = template_manager.all(
-                params={"_id": {"$in": subscription["next_templates"]}},
-                fields=["subject", "deception_score"],
-            )
-            resp, status_code = start_subscription(subscription_id, next_templates)
-        else:
-            resp, status_code = start_subscription(subscription_id)
+        resp, status_code = start_subscription(
+            subscription_id, subscription.get("next_templates", [])
+        )
         return jsonify(resp), status_code
 
     def delete(self, subscription_id):

--- a/src/utils/safelist_testing.py
+++ b/src/utils/safelist_testing.py
@@ -39,6 +39,7 @@ def test_subscription(subscription_id, contacts):
             "sending_profile_id",
             "customer_id",
             "templates_selected",
+            "next templates",
             "phish_header",
         ],
     )

--- a/src/utils/subscriptions.py
+++ b/src/utils/subscriptions.py
@@ -105,6 +105,8 @@ def start_subscription(subscription_id, templates_selected=[]):
 
     if templates_selected:
         update_data["templates_selected"] = templates_selected
+    else:
+        update_data["templates_selected"] = get_random_templates(subscription)
 
     next_templates_selected = get_random_templates(subscription)
     if next_templates_selected:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Utilize next templates when manually starting and stopping the subscription

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Request from the client

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

