### PR TITLE
Fix: revert get_all_customer_stats

### DIFF
--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -2488,283 +2488,49 @@ def get_nonhuman_orgs():
     return [x["asn_org"] for x in nonhuman_manager.all()]
 
 
-def get_all_customer_stats(nonhuman=False, nonhuman_orgs=[]):
+def get_all_customer_stats():
     """Get all customer stats."""
-    stats_pipeline = [
-        {"$unwind": {"path": "$timeline", "preserveNullAndEmptyArrays": True}},
-        {
-            "$match": {
-                "timeline.details.asn_org": {"$nin": nonhuman_orgs}
-                if not nonhuman
-                else {"$nin": []},
-            }
-        },
-        {
-            "$group": {
-                "_id": "$deception_level",
-                "sent_count": {
-                    "$sum": {"$cond": [{"$ne": ["$timeline.message", "clicked"]}, 1, 0]}
-                },
-                "clicked": {
-                    "$sum": {"$cond": [{"$eq": ["$timeline.message", "clicked"]}, 1, 0]}
-                },
-                "click_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "clicked"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-                "opened": {
-                    "$sum": {"$cond": [{"$eq": ["$timeline.message", "opened"]}, 1, 0]}
-                },
-                "open_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "opened"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-                "reported": {
-                    "$sum": {
-                        "$cond": [{"$eq": ["$timeline.message", "reported"]}, 1, 0]
-                    }
-                },
-                "report_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "reported"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-            }
-        },
-        {
-            "$project": {
-                "sent.count": "$sent_count",
-                "clicked.count": "$clicked",
-                "clicked.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$clicked", "$sent_count"]}, 4]},
-                    ]
-                },
-                "clicked.average": {"$sum": [{"$avg": "$click_times"}, 0]},
-                "clicked.maximum": {"$sum": [{"$max": "$click_times"}, 0]},
-                "clicked.minimum": {"$sum": [{"$min": "$click_times"}, 0]},
-                "clicked.median": "$click_times",
-                "opened.count": "$opened",
-                "opened.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$opened", "$sent_count"]}, 4]},
-                    ]
-                },
-                "opened.average": {"$sum": [{"$avg": "$open_times"}, 0]},
-                "opened.maximum": {"$sum": [{"$max": "$open_times"}, 0]},
-                "opened.minimum": {"$sum": [{"$min": "$open_times"}, 0]},
-                "opened.median": "$open_times",
-                "reported.count": "$reported",
-                "reported.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$reported", "$sent_count"]}, 4]},
-                    ]
-                },
-                "reported.average": {"$sum": [{"$avg": "$report_times"}, 0]},
-                "reported.maximum": {"$sum": [{"$max": "$report_times"}, 0]},
-                "reported.minimum": {"$sum": [{"$min": "$report_times"}, 0]},
-                "reported.median": "$report_times",
-            }
-        },
-    ]
-    stats = target_manager.aggregate(stats_pipeline)
-    # format from list into dictionary
-    stats = {item["_id"]: item for item in stats}
-    all_stats_pipeline = [
-        {"$unwind": {"path": "$timeline", "preserveNullAndEmptyArrays": True}},
-        {
-            "$match": {
-                "timeline.details.asn_org": {"$nin": nonhuman_orgs}
-                if not nonhuman
-                else {"$nin": []},
-            }
-        },
-        {
-            "$group": {
-                "_id": None,
-                "sent_count": {
-                    "$sum": {"$cond": [{"$ne": ["$timeline.message", "clicked"]}, 1, 0]}
-                },
-                "clicked": {
-                    "$sum": {"$cond": [{"$eq": ["$timeline.message", "clicked"]}, 1, 0]}
-                },
-                "click_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "clicked"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-                "opened": {
-                    "$sum": {"$cond": [{"$eq": ["$timeline.message", "opened"]}, 1, 0]}
-                },
-                "open_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "opened"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-                "reported": {
-                    "$sum": {
-                        "$cond": [{"$eq": ["$timeline.message", "reported"]}, 1, 0]
-                    }
-                },
-                "report_times": {
-                    "$push": {
-                        "$cond": [
-                            {"$eq": ["$timeline.message", "reported"]},
-                            {
-                                "$divide": [
-                                    {"$subtract": ["$timeline.time", "$sent_date"]},
-                                    1000,
-                                ]
-                            },
-                            "$$REMOVE",
-                        ]
-                    }
-                },
-            }
-        },
-        {
-            "$project": {
-                "sent.count": "$sent_count",
-                "clicked.count": "$clicked",
-                "clicked.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$clicked", "$sent_count"]}, 4]},
-                    ]
-                },
-                "clicked.average": {"$sum": [{"$avg": "$click_times"}, 0]},
-                "clicked.maximum": {"$sum": [{"$max": "$click_times"}, 0]},
-                "clicked.minimum": {"$sum": [{"$min": "$click_times"}, 0]},
-                "clicked.median": "$click_times",
-                "opened.count": "$opened",
-                "opened.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$opened", "$sent_count"]}, 4]},
-                    ]
-                },
-                "opened.average": {"$sum": [{"$avg": "$open_times"}, 0]},
-                "opened.maximum": {"$sum": [{"$max": "$open_times"}, 0]},
-                "opened.minimum": {"$sum": [{"$min": "$open_times"}, 0]},
-                "opened.median": "$open_times",
-                "reported.count": "$reported",
-                "reported.ratio": {
-                    "$cond": [
-                        {"$eq": ["$sent_count", 0]},
-                        0,
-                        {"$round": [{"$divide": ["$reported", "$sent_count"]}, 4]},
-                    ]
-                },
-                "reported.average": {"$sum": [{"$avg": "$report_times"}, 0]},
-                "reported.maximum": {"$sum": [{"$max": "$report_times"}, 0]},
-                "reported.minimum": {"$sum": [{"$min": "$report_times"}, 0]},
-                "reported.median": "$report_times",
-            }
-        },
-    ]
-    all_stats = target_manager.aggregate(all_stats_pipeline)
-    empty_stat = {
-        "clicked": {
-            "average": 0,
-            "count": 0,
-            "maximum": 0,
-            "median": 0,
-            "minimum": 0,
-            "ratio": 0,
-        },
-        "opened": {
-            "average": 0,
-            "count": 0,
-            "maximum": 0,
-            "median": 0,
-            "minimum": 0,
-            "ratio": 0,
-        },
-        "reported": {
-            "average": 0,
-            "count": 0,
-            "maximum": 0,
-            "median": 0,
-            "minimum": 0,
-            "ratio": 0,
-        },
-        "sent": {"count": 0},
-    }
+    levels = ["all", "low", "moderate", "high"]
+    actions = ["sent", "opened", "clicked", "reported"]
+    all_stats = {}
+    for level in levels:
+        all_stats[level] = {}
+        for action in actions:
+            all_stats[level][action] = {"count": 0, "ratios": []}
 
-    stats["all"] = all_stats[0] if len(all_stats) > 0 else empty_stat
-    stats["low"] = stats["low"] if "low" in stats.keys() else empty_stat
-    stats["moderate"] = stats["moderate"] if "moderate" in stats.keys() else empty_stat
-    stats["high"] = stats["high"] if "high" in stats.keys() else empty_stat
+    cycles = cycle_manager.all(fields=["_id", "dirty_stats", "stats"])
+    for cycle in cycles:
+        if cycle.get("dirty_stats", True):
+            cycle = cycle_manager.get(cycle["_id"])
+            get_cycle_stats(cycle)
 
-    # calculate medians on the python side
-    for level in ["all", "low", "moderate", "high"]:
-        del stats[level]["_id"]
-        for event in ["clicked", "opened", "reported"]:
-            if stats[level][event]["median"] == 0:
-                pass
-            elif len(stats[level][event]["median"]) > 0:
-                stats[level][event]["median"] = statistics.median(
-                    stats[level][event]["median"]
+        for level in levels:
+            for action in actions:
+                all_stats[level][action]["count"] += cycle["stats"]["stats"][level][
+                    action
+                ]["count"]
+                if action != "sent":
+                    all_stats[level][action]["ratios"].append(
+                        cycle["stats"]["stats"][level][action]["ratio"]
+                    )
+
+    # Process average of ratios
+    for level in levels:
+        for action in actions:
+            if action != "sent":
+                ratios = all_stats[level][action]["ratios"]
+                length = len(ratios)
+                all_stats[level][action]["average"] = (
+                    sum(ratios) / length if length != 0 else 0
                 )
-            else:
-                stats[level][event]["median"] = 0
+                all_stats[level][action]["minimum"] = min(ratios) if ratios else 0
+                all_stats[level][action]["maximum"] = max(ratios) if ratios else 0
+                all_stats[level][action]["median"] = (
+                    statistics.median(ratios) if ratios else 0
+                )
 
-    return stats
+    process_ratios(all_stats)
+    return all_stats
 
 
 def get_sending_profile_metrics(subscriptions, sending_profiles):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Reverting get_all_customer_stats to python calculations until I can resolve the pdf report dependencies

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

PDF reports are broken

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.
